### PR TITLE
Fixed setup.py to work in clean environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
         'Development Status :: 4 - Beta',
         ],
     install_requires = [
-        'numpy', 'scipy', 'matplotlib', 'neuron', 'Cython', 'alias_method'
+        'numpy', 'scipy', 'matplotlib', 'neuron', 'Cython'
         ],
     provides = ['LFPy'],
     )

--- a/setup.py
+++ b/setup.py
@@ -11,20 +11,19 @@ if version < '2.2.3':
     DistributionMetadata.classifiers = None
     DistributionMetadata.download_url = None
 
-from distutils.core import setup 
+from distutils.core import setup
 from distutils.extension import Extension
-import numpy
 try:
     from Cython.Distutils import build_ext
     cmdclass = { 'build_ext' : build_ext}
     ext_modules = [
-        Extension('LFPy.lfpcalc', 
+        Extension('LFPy.lfpcalc',
         ['LFPy/lfpcalc.pyx'],
         include_dirs=[numpy.get_include()]),
-        Extension('LFPy.run_simulation', 
+        Extension('LFPy.run_simulation',
         ['LFPy/run_simulation.pyx'],
         include_dirs=[numpy.get_include()]),
-        Extension('LFPy.alias_method', 
+        Extension('LFPy.alias_method',
         ['LFPy/alias_method.pyx'],
         include_dirs=[numpy.get_include()]),
         ]
@@ -55,7 +54,7 @@ with open('README.md') as file:
 
 setup(
     name = "LFPy",
-    version = "1.1.0", 
+    version = "1.1.0",
     maintainer = "Espen Hagen",
         maintainer_email = 'e.hagen@fz-juelich.de',
     packages = ['LFPy'],
@@ -67,7 +66,7 @@ setup(
                               os.path.join('powerpc', '*'),
                               os.path.join('powerpc', '.libs', '*'),
                               ]},
-    cmdclass = cmdclass, 
+    cmdclass = cmdclass,
     ext_modules = ext_modules,
     url='http://LFPy.github.io',
     license='LICENSE',
@@ -87,8 +86,8 @@ setup(
         'Intended Audience :: Science/Research',
         'Development Status :: 4 - Beta',
         ],
-    requires = [
-        'numpy', 'scipy', 'matplotlib', 'neuron', 'Cython'
+    install_requires = [
+        'numpy', 'scipy', 'matplotlib', 'neuron', 'Cython', 'alias_method'
         ],
     provides = ['LFPy'],
     )


### PR DESCRIPTION
* Removed "import numpy" from setup.py because numpy isn't used (or installed).
* Changed requires to install_requires (requires is not a valid keyword).

This makes it possible to run

  pip install lfpy

in a clean environment, such as a new virtualenv, and have all
dependencies installed automatically.

(Sorry about the whitespace changes. It appears the Atom editor removes them by default. I disabled that feature now.)