### PR TITLE
Fixed setup.py to work in clean environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,17 +11,16 @@ if version < '2.2.3':
     DistributionMetadata.classifiers = None
     DistributionMetadata.download_url = None
 
-from distutils.core import setup 
+from distutils.core import setup
 from distutils.extension import Extension
-import numpy
 try:
     from Cython.Distutils import build_ext
     cmdclass = { 'build_ext' : build_ext}
     ext_modules = [
-        Extension('LFPy.lfpcalc', 
+        Extension('LFPy.lfpcalc',
         ['LFPy/lfpcalc.pyx'],
         include_dirs=[numpy.get_include()]),
-        Extension('LFPy.run_simulation', 
+        Extension('LFPy.run_simulation',
         ['LFPy/run_simulation.pyx'],
         include_dirs=[numpy.get_include()]),
         ]
@@ -52,7 +51,7 @@ with open('README.md') as file:
 
 setup(
     name = "LFPy",
-    version = "1.1.0", 
+    version = "1.1.0",
     maintainer = "Espen Hagen",
         maintainer_email = 'e.hagen@fz-juelich.de',
     packages = ['LFPy'],
@@ -64,7 +63,7 @@ setup(
                               os.path.join('powerpc', '*'),
                               os.path.join('powerpc', '.libs', '*'),
                               ]},
-    cmdclass = cmdclass, 
+    cmdclass = cmdclass,
     ext_modules = ext_modules,
     url='http://LFPy.github.io',
     license='LICENSE',
@@ -84,7 +83,7 @@ setup(
         'Intended Audience :: Science/Research',
         'Development Status :: 4 - Beta',
         ],
-    requires = [
+    install_requires = [
         'numpy', 'scipy', 'matplotlib', 'neuron', 'Cython'
         ],
     provides = ['LFPy'],


### PR DESCRIPTION
* Removed "import numpy" from setup.py because numpy isn't used (or installed).
* Changed requires to install_requires (requires is not a valid keyword).

This makes it possible to run

  pip install lfpy

in a clean environment, such as a new virtualenv, and have all
dependencies installed automatically.

(Sorry about the whitespace changes. It appears the Atom editor removes them by default. I disabled that feature now.)