### PR TITLE
Added celsius parameter to cell class, and updated example2.py

### DIFF
--- a/LFPy/cell.py
+++ b/LFPy/cell.py
@@ -58,6 +58,7 @@ class Cell(object):
         custom_fun: [None]: list of model-specific functions with args
         custom_fun_args: [None]: list of args passed to custom_fun functions
         pt3d: True/[False]: use pt3d-info of the cell geometries switch
+        celsius: [None]: Temperature in celsius. If nothing is specified here or in custom code it is 6.3 C
         verbose: True/[False]: verbose output switch
     
     Usage of cell class:
@@ -98,6 +99,7 @@ class Cell(object):
                     custom_fun=None,
                     custom_fun_args=None,
                     pt3d=False,
+                    celsius=None,
                     verbose=False):
         '''
         Initialization of the Cell object.
@@ -196,7 +198,7 @@ class Cell(object):
         self._set_nsegs(nsegs_method, lambda_f, d_lambda, max_nsegs_length)
         self.totnsegs = self._calc_totnsegs()
         if self.verbose:
-            print(("Total number of segments: %i" % self.totnsegs))
+            print("Total number of segments: %i" % self.totnsegs)
         
         #extract pt3d info from NEURON, and set these with the same rotation
         #and position in space as in our simulations, assuming RH rule, which
@@ -213,8 +215,11 @@ class Cell(object):
                 print('no soma, using the midpoint if initial segment.')
         self.set_rotation(**self.default_rotation)
 
-    
-
+        if celsius is not None:
+            if neuron.h.celsius != 6.3:
+                print("Overwriting custom temperature of %1.2f. New temperature is %1.2f"
+                      % (neuron.h.celsius, celsius))
+            neuron.h.celsius = celsius
 
 
     def _load_geometry(self):
@@ -234,14 +239,14 @@ class Cell(object):
                 Import = neuron.h.Import3d_Neurolucida3()
                 if not self.verbose:
                     Import.quiet = 1
-            elif fileEnding == 'swc' or fileEnding ==  'SWC':
+            elif fileEnding == 'swc' or fileEnding == 'SWC':
                 Import = neuron.h.Import3d_SWC_read()
-            elif fileEnding == 'xml' or fileEnding ==  'XML':
+            elif fileEnding == 'xml' or fileEnding == 'XML':
                 Import = neuron.h.Import3d_MorphML()
             else:
                 raise ValueError('%s is not a recognised morphology file format!'
                                  ).with_traceback(
-                    'Should be either .hoc, .asc, .swc, .xml!' %self.morphology)
+                    'Should be either .hoc, .asc, .swc, .xml!' % self.morphology)
             
             #assuming now that morphologies file is the correct format
             try:

--- a/examples/example2.py
+++ b/examples/example2.py
@@ -55,6 +55,7 @@ cellParameters = {
     'tstartms' : -159,
     'tstopms' : 10,
     'v_init' : -60,
+    'celsius': 34,
     'pt3d' : True,
 }
 
@@ -89,7 +90,7 @@ cell.set_rotation(x=4.729, y=-3.166)
 #Override passive reversal potential, AP is generated
 for sec in cell.allseclist:
     for seg in sec:
-        seg.e_pas = -59.7
+        seg.e_pas = -59.5
 
 ##perform NEURON simulation, results saved as attributes in the cell instance
 cell.simulate(electrode=electrode)
@@ -167,7 +168,7 @@ def plotstuff(cell, electrode):
 
     #plot extracellular spike in detail
     ind = np.where(electrode.LFP == electrode.LFP.min())[0][0]
-    timeind = (cell.tvec >= 0) & (cell.tvec <= 4)
+    timeind = (cell.tvec >= 0) & (cell.tvec <= 10)
     xticks = np.arange(10)
     xticklabels = xticks
     LFPtrace = electrode.LFP[ind, ]


### PR DESCRIPTION
Temperature can be given to Cell class as 'celsius', which defaults to None, meaning that the temperature will be set to either the NEURON default of 6.3 C, or whatever it is specified to in "custom_code" or "custom_fun". If a value is given, and the temperature is already set to something else than 6.3 (by e.g. "custom_code"), this will result in a printed message.