### PR TITLE
Calculation of current dipole moment during simulation time

### DIFF
--- a/LFPy/cell.py
+++ b/LFPy/cell.py
@@ -171,13 +171,20 @@ class Cell(object):
                 raise Exception("Could not load existent top-level cell")
         
         #Some parameters and lists initialised
-        if dt not in 2.**np.arange(-16, -1):
-            if self.verbose:
-                print('dt not a power of 2,')
-                print('cell.tvec errors may occur.')
-                print('Initialization will continue.')
-            else:
-                pass
+        try:
+            assert(tstartms <= 0)
+        except AssertionError:
+            raise AssertionError('tstartms must be <= 0.')
+
+        try:
+            assert(dt in 2.**np.arange(-16, -1))
+        except AssertionError:
+            if tstartms == 0.:
+                print('int(1./dt) not factorizable in base 2.' 
+                      'cell.tvec errors may occur, continuing initialization.')
+            elif tstartms < 0:
+                raise AssertionError('int(1./dt) must be factorizable in base 2 if tstartms < 0.')
+
         self.dt = dt
         
         self.tstartms = tstartms

--- a/LFPy/inputgenerators.py
+++ b/LFPy/inputgenerators.py
@@ -30,7 +30,7 @@ def stationary_poisson(nsyn, lambd, tstart, tstop):
     spiketimes = []
     for i in range(nsyn):
         spikecount = np.random.poisson(interval_s*lambd)
-        spikevec = np.empty(spikecount)
+        spikevec = np.zeros(spikecount)
         if spikecount == 0:
             spiketimes.append(spikevec)
         else:
@@ -63,7 +63,7 @@ def test_spiketimes(spiketime):
     """Test and sort spike times"""
     spiketimes = []
     spikecount = 1
-    spikevec = np.empty(spikecount)
+    spikevec = np.zeros(spikecount)
     spikevec = spiketime
     spiketimes.append(np.sort(spikevec))
     return spiketimes
@@ -73,7 +73,7 @@ def get_normal_spike_times(nsyn, mu, sigma, tstart, tstop):
     deviation sigma"""
     spiketimes = []
     spikecount = nsyn
-    spikevec = np.empty(spikecount)
+    spikevec = np.zeros(spikecount)
     spikevec = np.random.normal(mu, sigma)
     while (np.squeeze(spikevec) <= tstart) and \
             (np.squeeze(spikevec) >= tstop):

--- a/LFPy/run_simulation.pyx
+++ b/LFPy/run_simulation.pyx
@@ -79,7 +79,8 @@ def _run_simulation(cell, cvode, variable_dt=False, atol=0.001):
 def _run_simulation_with_electrode(cell, cvode, electrode=None,
                                    variable_dt=False, atol=0.001,
                                    to_memory=True, to_file=False,
-                                   file_name=None, dotprodcoeffs=None):
+                                   file_name=None, dotprodcoeffs=None,
+                                   rec_current_dipole_moment=False):
     """
     Running the actual simulation in NEURON.
     electrode argument used to determine coefficient
@@ -91,7 +92,7 @@ def _run_simulation_with_electrode(cell, cvode, electrode=None,
     cdef int totnsegs = cell.totnsegs
     cdef double tstopms = cell.tstopms
     cdef int counter
-    cdef int lendotrodcoeffs0
+    cdef int lendotprodcoeffs0
     cdef double interval
     cdef double t0
     cdef double ti
@@ -99,9 +100,11 @@ def _run_simulation_with_electrode(cell, cvode, electrode=None,
     cdef double dt = cell.dt
     cdef np.ndarray[DTYPE_t, ndim=2, negative_indices=False] coeffs
     cdef np.ndarray[DTYPE_t, ndim=1, negative_indices=False] imem = \
-        np.empty(totnsegs)
+        np.zeros(totnsegs)
     cdef np.ndarray[DTYPE_t, ndim=1, negative_indices=False] area = \
         cell.area.copy()
+    cdef np.ndarray[DTYPE_t, ndim=2, negative_indices=False] current_dipole_moment
+    cdef np.ndarray[DTYPE_t, ndim=2, negative_indices=False] midpoints
     
     #check if h5py exist and saving is possible
     try:
@@ -127,7 +130,7 @@ def _run_simulation_with_electrode(cell, cvode, electrode=None,
         dotprodcoeffs = []
     
     #just for safekeeping
-    lendotrodcoeffs0 = len(dotprodcoeffs)
+    lendotprodcoeffs0 = len(dotprodcoeffs)
      
     #access electrode object and append dotprodcoeffs        
     if electrode is not None:
@@ -187,23 +190,14 @@ def _run_simulation_with_electrode(cell, cvode, electrode=None,
     neuron.h.dt = dt
         
     #don't know if this is the way to do, but needed for variable dt method
-    if variable_dt:
+    if cell.dt <= 1E-8:
         cvode.active(1)
         cvode.atol(atol)
-    else:
-        cvode.active(0)
-        # allow fast calculation of i_membrane_
-        cvode.use_fast_imem(1)
     
-    #initialize state
+    #re-initialize state
     neuron.h.finitialize(cell.v_init)
-    
-    #initialize current- and record
-    if cvode.active():
-        cvode.re_init()
-    else:
-        neuron.h.fcurrent()
-    neuron.h.frecord_init()
+    neuron.h.frecord_init() # wrong voltages t=0 for tstartms < 0 otherwise
+    neuron.h.fcurrent()
     
     #Starting simulation at t != 0
     neuron.h.t = cell.tstartms
@@ -222,12 +216,12 @@ def _run_simulation_with_electrode(cell, cvode, electrode=None,
         interval = 100. / dt
         
     #temp vector to store membrane currents at each timestep
-    imem = np.empty(cell.totnsegs)
+    imem = np.zeros(cell.totnsegs)
     #LFPs for each electrode will be put here during simulation
     if to_memory:
         electrodesLFP = []
         for coeffs in dotprodcoeffs:
-            electrodesLFP.append(np.empty((coeffs.shape[0],
+            electrodesLFP.append(np.zeros((coeffs.shape[0],
                                     int(tstopms / dt + 1))))
     #LFPs for each electrode will be put here during simulations
     if to_file:
@@ -237,10 +231,17 @@ def _run_simulation_with_electrode(cell, cvode, electrode=None,
         el_LFP_file = h5py.File(file_name, 'w')
         i = 0
         for coeffs in dotprodcoeffs:
-            el_LFP_file['electrode{:03d}'.format(i)] = np.empty((coeffs.shape[0],
+            el_LFP_file['electrode{:03d}'.format(i)] = np.zeros((coeffs.shape[0],
                                             int(tstopms / dt + 1)))
             i += 1
 
+    # create a 2D array representation of segment midpoints for dot product
+    # with transmembrane currents when computing dipole moment
+    if rec_current_dipole_moment:
+        current_dipole_moment = cell.current_dipole_moment.copy()
+        cell.current_dipole_moment = np.array([[]])
+        midpoints = np.c_[cell.xmid, cell.ymid, cell.zmid]
+        
     #run fadvance until time limit, and calculate LFPs for each timestep
     while neuron.h.t < tstopms:
         if neuron.h.t >= 0:
@@ -249,6 +250,9 @@ def _run_simulation_with_electrode(cell, cvode, electrode=None,
                 for seg in sec:
                     imem[i] = seg.i_membrane_
                     i += 1
+
+            if rec_current_dipole_moment:
+                current_dipole_moment[tstep, ] = np.dot(imem, midpoints)
 
             if to_memory:
                 for j, coeffs in enumerate(dotprodcoeffs):
@@ -259,6 +263,7 @@ def _run_simulation_with_electrode(cell, cvode, electrode=None,
                     el_LFP_file['electrode{:03d}'.format(j)
                                 ][:, tstep] = np.dot(coeffs, imem)
             
+                
             tstep += 1
         neuron.h.fadvance()
         counter += 1
@@ -278,10 +283,12 @@ def _run_simulation_with_electrode(cell, cvode, electrode=None,
                 imem[i] = seg.i_membrane_
                 i += 1
 
+        if rec_current_dipole_moment:
+            current_dipole_moment[tstep, ] = np.dot(imem, midpoints)
+
         if to_memory:
             for j, coeffs in enumerate(dotprodcoeffs):
                 electrodesLFP[j][:, tstep] = np.dot(coeffs, imem)
-                #j += 1
         if to_file:
             for j, coeffs in enumerate(dotprodcoeffs):
                 el_LFP_file['electrode{:03d}'.format(j)
@@ -290,25 +297,29 @@ def _run_simulation_with_electrode(cell, cvode, electrode=None,
     except:
         pass
     
+    # update current dipole moment values
+    if rec_current_dipole_moment:
+        cell.current_dipole_moment = current_dipole_moment
+    
     # Final step, put LFPs in the electrode object, superimpose if necessary
     # If electrode.perCellLFP, store individual LFPs
     if to_memory:
         #the first few belong to input dotprodcoeffs
-        cell.dotprodresults = electrodesLFP[:lendotrodcoeffs0]
+        cell.dotprodresults = electrodesLFP[:lendotprodcoeffs0]
         #the remaining belong to input electrode arguments
         if electrodes is not None:
             for j, LFP in enumerate(electrodesLFP):
-                if not j < lendotrodcoeffs0:
-                    if hasattr(electrodes[j-lendotrodcoeffs0], 'LFP'):
-                        electrodes[j-lendotrodcoeffs0].LFP += LFP
+                if not j < lendotprodcoeffs0:
+                    if hasattr(electrodes[j-lendotprodcoeffs0], 'LFP'):
+                        electrodes[j-lendotprodcoeffs0].LFP += LFP
                     else:
-                        electrodes[j-lendotrodcoeffs0].LFP = LFP
+                        electrodes[j-lendotprodcoeffs0].LFP = LFP
                     #will save each cell contribution separately
-                    if electrodes[j-lendotrodcoeffs0].perCellLFP:
+                    if electrodes[j-lendotprodcoeffs0].perCellLFP:
                         if not hasattr(electrodes[j], 'CellLFP'):
-                            electrodes[j-lendotrodcoeffs0].CellLFP = []
-                        electrodes[j-lendotrodcoeffs0].CellLFP.append(LFP)
-                    electrodes[j-lendotrodcoeffs0].electrodecoeff = dotprodcoeffs[j]
+                            electrodes[j-lendotprodcoeffs0].CellLFP = []
+                        electrodes[j-lendotprodcoeffs0].CellLFP.append(LFP)
+                    electrodes[j-lendotprodcoeffs0].electrodecoeff = dotprodcoeffs[j]
     
     if to_file:
         el_LFP_file.close()

--- a/LFPy/testing.py
+++ b/LFPy/testing.py
@@ -36,7 +36,7 @@ class testLFPy(unittest.TestCase):
         LFP_LFPy = self.stickSimulation(method='pointsource')
         
         #create LFPs using the analytical approach
-        time = np.linspace(0, 100, 10001)
+        time = np.linspace(0, 100, 100*2**6+1)
         R = np.ones(11)*100
         Z = np.linspace(1000, 0, 11)
         
@@ -55,7 +55,7 @@ class testLFPy(unittest.TestCase):
         LFP_LFPy = self.stickSimulation(method='linesource')
         
         #create LFPs using the analytical approach
-        time = np.linspace(0, 100, 10001)
+        time = np.linspace(0, 100, 100*2**6+1)
         R = np.ones(11)*100
         Z = np.linspace(1000, 0, 11)
         
@@ -74,7 +74,7 @@ class testLFPy(unittest.TestCase):
         LFP_LFPy = self.stickSimulation(method='som_as_point')
         
         #create LFPs using the analytical approach
-        time = np.linspace(0, 100, 10001)
+        time = np.linspace(0, 100, 100*2**6+1)
         R = np.ones(11)*100
         Z = np.linspace(1000, 0, 11)
         
@@ -94,7 +94,7 @@ class testLFPy(unittest.TestCase):
         LFP_LFPy = self.stickSimulationDotprodcoeffs(method='pointsource')
         
         #create LFPs using the analytical approach
-        time = np.linspace(0, 100, 10001)
+        time = np.linspace(0, 100, 100*2**6+1)
         R = np.ones(11)*100
         Z = np.linspace(1000, 0, 11)
         
@@ -113,7 +113,7 @@ class testLFPy(unittest.TestCase):
         LFP_LFPy = self.stickSimulationDotprodcoeffs(method='linesource')
         
         #create LFPs using the analytical approach
-        time = np.linspace(0, 100, 10001)
+        time = np.linspace(0, 100, 100*2**6+1)
         R = np.ones(11)*100
         Z = np.linspace(1000, 0, 11)
         
@@ -132,7 +132,7 @@ class testLFPy(unittest.TestCase):
         LFP_LFPy = self.stickSimulationDotprodcoeffs(method='som_as_point')
         
         #create LFPs using the analytical approach
-        time = np.linspace(0, 100, 10001)
+        time = np.linspace(0, 100, 100*2**6+1)
         R = np.ones(11)*100
         Z = np.linspace(1000, 0, 11)
         
@@ -153,7 +153,7 @@ class testLFPy(unittest.TestCase):
             contactRadius=10, contactNPoints=100, method='som_as_point')
         
         #create LFPs using the analytical approach
-        time = np.linspace(0, 100, 10001)
+        time = np.linspace(0, 100, 100*2**6+1)
         R = np.ones(11)*100
         Z = np.linspace(1000, 0, 11)
         
@@ -173,7 +173,7 @@ class testLFPy(unittest.TestCase):
             contactRadius=10, contactNPoints=100, method='linesource')
         
         #create LFPs using the analytical approach
-        time = np.linspace(0, 100, 10001)
+        time = np.linspace(0, 100, 100*2**6+1)
         R = np.ones(11)*100
         Z = np.linspace(1000, 0, 11)
         
@@ -193,7 +193,7 @@ class testLFPy(unittest.TestCase):
             contactRadius=10, contactNPoints=100, method='som_as_point')
         
         #create LFPs using the analytical approach
-        time = np.linspace(0, 100, 10001)
+        time = np.linspace(0, 100, 100*2**6+1)
         R = np.ones(11)*100
         Z = np.linspace(1000, 0, 11)
         
@@ -378,55 +378,13 @@ class testLFPy(unittest.TestCase):
         stickParams = {
             'dt' : 0.1,
             'tstartms' : -100,
-            'tstopms' : 100,
-        }
-        
-        tvec = self.stickSimulationTesttvec(**stickParams)
-        tvec_numpy = np.linspace(0, stickParams['tstopms'],
-                    stickParams['tstopms']/stickParams['dt'] + 1)
-        
-        self.assertEqual(tvec.size, tvec_numpy.size)
-
-    def test_cell_tvec_13(self):
-        stickParams = {
-            'dt' : 0.10,
-            'tstartms' : -100,
-            'tstopms' : 100,
-        }
-        
-        tvec = self.stickSimulationTesttvec(**stickParams)
-        tvec_numpy = np.linspace(0, stickParams['tstopms'],
-                    stickParams['tstopms']/stickParams['dt'] + 1)
-        
-        for i in range(tvec.size):
-            self.assertAlmostEqual(tvec[i], tvec_numpy[i])
-
-    def test_cell_tvec_14(self):
-        stickParams = {
-            'dt' : 0.1,
-            'tstartms' : -100,
             'tstopms' : 10000,
         }
         
-        tvec = self.stickSimulationTesttvec(**stickParams)
-        tvec_numpy = np.linspace(0, stickParams['tstopms'],
-                    stickParams['tstopms']/stickParams['dt'] + 1)
-        
-        self.assertEqual(tvec.size, tvec_numpy.size)
-
-    def test_cell_tvec_15(self):
-        stickParams = {
-            'dt' : 0.1,
-            'tstartms' : -100,
-            'tstopms' : 10000,
-        }
-        
-        tvec = self.stickSimulationTesttvec(**stickParams)
-        tvec_numpy = np.linspace(0, stickParams['tstopms'],
-                    stickParams['tstopms']/stickParams['dt'] + 1)
-        
-        for i in range(tvec.size):
-            self.assertAlmostEqual(tvec[i], tvec_numpy[i])    
+        try:
+            self.stickSimulationTesttvec(**stickParams)
+        except AssertionError:
+            pass
 
     def test_alias_method_01(self):
         """deterministic probabilities 0.0 and 1.0"""
@@ -1018,18 +976,18 @@ class testLFPy(unittest.TestCase):
             'Ra' : 150,
             'tstartms' : -100,
             'tstopms' : 100,
-            'dt' : 0.1,
+            'dt' : 2**-4,
             'nsegs_method' : 'lambda_f',
             'lambda_f' : 100,   
         }
                 
         stimParams = {
             'pptype' : 'SinSyn',
-            'delay' : 0., # -100
+            'delay' : 0., 
             'dur' : 1000.,
             'pkamp' : 1.,
             'freq' : 100.,
-            'phase' : 0, #-np.pi/2,
+            'phase' : 0,
             'bias' : 0.,
             'record_current' : False
         }
@@ -1037,12 +995,42 @@ class testLFPy(unittest.TestCase):
         for idx in range(31): #31 segments
             if idx != 15: # no net dipole moment because of stick symmetry
                 stick = LFPy.Cell(**stickParams)
-                synapse = LFPy.StimIntElectrode(stick, stick.get_closest_idx(0, 0, 1000),
+                synapse = LFPy.StimIntElectrode(stick, idx=idx,
                                        **stimParams)
                 stick.simulate(rec_imem=True, rec_current_dipole_moment=True)
                 p = np.dot(stick.imem.T, np.c_[stick.xmid, stick.ymid, stick.zmid])
                 np.testing.assert_allclose(p, stick.current_dipole_moment)
 
+    def test_cell_simulate_current_dipole_moment_02(self):
+        stickParams = {
+            'morphology' : os.path.join(LFPy.__path__[0], 'stick.hoc'),
+            'rm' : 30000,
+            'cm' : 1,
+            'Ra' : 150,
+            'tstartms' : -100,
+            'tstopms' : 100,
+            'dt' : 2**-4,
+            'nsegs_method' : 'lambda_f',
+            'lambda_f' : 100,   
+        }
+                
+        stimParams = {
+            'e' : 0,                                # reversal potential
+            'syntype' : 'Exp2Syn',                   # synapse type
+            'tau1' : 0.1,                              # syn. time constant
+            'tau2' : 2.,                              # syn. time constant
+            'weight' : 0.01,
+        }
+                
+        for idx in range(31): #31 segments
+            if idx != 15: # no net dipole moment because of stick symmetry
+                stick = LFPy.Cell(**stickParams)
+                synapse = LFPy.Synapse(stick, idx=idx,
+                                       **stimParams)
+                synapse.set_spike_times(np.array([10., 20., 30., 40., 50.]))
+                stick.simulate(rec_imem=True, rec_current_dipole_moment=True)
+                p = np.dot(stick.imem.T, np.c_[stick.xmid, stick.ymid, stick.zmid])
+                np.testing.assert_allclose(p, stick.current_dipole_moment)
     
     def test_cell_tstart_00(self):
         stickParams = {
@@ -1050,7 +1038,7 @@ class testLFPy(unittest.TestCase):
             'rm' : 30000,
             'cm' : 1,
             'Ra' : 150,
-            'dt' : 0.1,
+            'dt' : 2**-4,
             'nsegs_method' : 'lambda_f',
             'lambda_f' : 100,   
         }
@@ -1368,7 +1356,7 @@ class testLFPy(unittest.TestCase):
             'Ra' : 150,
             'tstartms' : -100,
             'tstopms' : 100,
-            'dt' : 0.01,
+            'dt' : 2**-6,
             'nsegs_method' : 'lambda_f',
             'lambda_f' : 100,
             
@@ -1413,7 +1401,7 @@ class testLFPy(unittest.TestCase):
             'Ra' : 150,
             'tstartms' : -100,
             'tstopms' : 100,
-            'dt' : 0.01,
+            'dt' : 2**-6,
             'nsegs_method' : 'lambda_f',
             'lambda_f' : 100,
             
@@ -1462,7 +1450,7 @@ class testLFPy(unittest.TestCase):
             'Ra' : 150,
             'tstartms' : -100,
             'tstopms' : 100,
-            'dt' : 0.01,
+            'dt' : 2**-6,
             'nsegs_method' : 'lambda_f',
             'lambda_f' : 100,
             

--- a/LFPy/tools.py
+++ b/LFPy/tools.py
@@ -42,7 +42,7 @@ def noise_brown(ncols, nrows=1, weight=1, filter=None, filterargs=None):
     if filter is not None:
         coeff_b, coeff_a = list(filter(**filterargs))
     
-    noise = np.empty((nrows, ncols))    
+    noise = np.zeros((nrows, ncols))    
     for i in range(nrows):
         signal = np.random.normal(size=ncols+10000).cumsum()
         if filter is not None:


### PR DESCRIPTION
Implementation of calculating current dipole moments from transmembrane currents during the main simulation loop, such that transmembrane currents do not have to be recorded for the whole simulation duration. The implementation is based on the description in Linden et al. (2010) J Comput Neurosci.

Notes:

1. Tests of this method fail if `tstartms` is less than 0 as a time shift of `-dt` is introduced.
2. If `rec_current_dipole_moment=True` is supplied to `LFPy.Cell.simulate()`, the x,y,z-components of the  moment is stored in the attribute `cell.current_dipole_moment`
