### PR TITLE
removed Cell.simulate() args rec_isyn, rec_vmemsyn, rec_istim, rec_vmemstim

### DIFF
--- a/LFPy/cell.py
+++ b/LFPy/cell.py
@@ -566,12 +566,18 @@ class Cell(object):
                                                       self.dt+1))
                         synirec.record(syn._ref_i, self.dt)
                         self.synireclist.append(synirec)
+                    else:
+                        synirec = neuron.h.Vector(0)
+                        self.synireclist.append(synirec)
 
                     #record potential
                     if record_potential:
                         synvrec = neuron.h.Vector(int(self.tstop /
                                                       self.dt+1))
                         synvrec.record(seg._ref_v, self.dt)
+                        self.synvreclist.append(synvrec)
+                    else:
+                        synvrec = neuron.h.Vector(0)
                         self.synvreclist.append(synvrec)
 
                 i += 1
@@ -637,6 +643,10 @@ class Cell(object):
                                                        self.dt+1))
                         stimirec.record(stim._ref_i, self.dt)
                         self.stimireclist.append(stimirec)
+                    else:
+                        stimirec = neuron.h.Vector(0)
+                        self.stimireclist.append(stimirec)
+                        
                     
                     # record potential
                     if record_potential:
@@ -644,6 +654,10 @@ class Cell(object):
                                                       self.dt+1))
                         stimvrec.record(seg._ref_v, self.dt)
                         self.stimvreclist.append(stimvrec)
+                    else:
+                        stimvrec = neuron.h.Vector(0)
+                        self.stimvreclist.append(stimvrec)
+
                     
                 i += 1
 

--- a/LFPy/test/test_cell.py
+++ b/LFPy/test/test_cell.py
@@ -1114,6 +1114,6 @@ def cell_w_synapse_from_sections(sections=None):
     cell = LFPy.Cell(**cellParams)
     synapse = LFPy.Synapse(cell, **synapse_parameters)
     synapse.set_spike_times(np.array([1.]))
-    cell.simulate(rec_imem = True, rec_isyn = True, rec_vmem = True)
+    cell.simulate(rec_imem=True, rec_vmem=True)
     d_list, iaxial = cell.get_axial_currents_from_vmem()
     return cell, synapse, d_list, iaxial

--- a/LFPy/test/test_pointprocess.py
+++ b/LFPy/test/test_pointprocess.py
@@ -47,7 +47,7 @@ class testSynapse(unittest.TestCase):
                            weight=1., tau=5., record_current=True,
                            record_potential=True)
         syn.set_spike_times(np.array([10.]))
-        cell.simulate(rec_isyn=True, rec_vmemsyn=True)
+        cell.simulate()
         
         i = np.zeros(cell.tvec.size)
         i[cell.tvec > 10.] = -np.exp(-np.arange((cell.tvec > 10.).sum())*cell.dt / 5.)
@@ -68,7 +68,7 @@ class testStimIntElectrode(unittest.TestCase):
                             amp=1., dur=20., delay=10.,
                             record_potential=True,
                             record_current=True)
-        cell.simulate(rec_istim=True, rec_vmemstim=True)
+        cell.simulate()
         # stim.collect_potential(cell) 
         gt = np.zeros(cell.tvec.size)
         gt[(cell.tvec > 10.) & (cell.tvec <= 30.)] = 1.
@@ -95,7 +95,7 @@ class testStimIntElectrode(unittest.TestCase):
                                         'amp[2]' : -65,
                                         'dur[2]' : 10,
                                    })
-        cell.simulate(rec_vmemstim=True)
+        cell.simulate()
         # stim.collect_potential(cell) 
         gt = np.zeros(cell.tvec.size)-65.
         gt[(cell.tvec > 10.) & (cell.tvec <= 30.)] = -55.
@@ -122,7 +122,7 @@ class testStimIntElectrode(unittest.TestCase):
                                         'amp3' : -65,
                                         'dur3' : 10,
                                    })
-        cell.simulate(rec_vmemstim=True)
+        cell.simulate()
         # stim.collect_potential(cell)
         gt = np.zeros(cell.tvec.size)-65.
         gt[(cell.tvec > 10.) & (cell.tvec <= 30.)] = -55.

--- a/LFPy/test/test_recextelectrode.py
+++ b/LFPy/test/test_recextelectrode.py
@@ -226,7 +226,7 @@ def stickSimulation(method):
 
     synapse = LFPy.StimIntElectrode(stick, stick.get_closest_idx(0, 0, 1000),
                            **stimParams)
-    stick.simulate(electrode, rec_imem=True, rec_istim=True, rec_vmem=True)
+    stick.simulate(electrode, rec_imem=True, rec_vmem=True)
 
     return electrode.LFP
 
@@ -278,7 +278,7 @@ def stickSimulationAveragingElectrode(contactRadius, contactNPoints, method):
 
     synapse = LFPy.StimIntElectrode(stick, stick.get_closest_idx(0, 0, 1000),
                            **stimParams)
-    stick.simulate(electrode, rec_imem=True, rec_istim=True, rec_vmem=True)
+    stick.simulate(electrode, rec_imem=True, rec_vmem=True)
 
     return electrode.LFP
 
@@ -334,7 +334,7 @@ def stickSimulationDotprodcoeffs(method):
     synapse = LFPy.StimIntElectrode(stick, stick.get_closest_idx(0, 0, 1000),
                            **stimParams)
     stick.simulate(dotprodcoeffs=electrode.LFP,
-                   rec_imem=True, rec_istim=True, rec_vmem=True)
+                   rec_imem=True, rec_vmem=True)
 
     return stick.dotprodresults[0]
 

--- a/examples/example1.py
+++ b/examples/example1.py
@@ -95,7 +95,7 @@ point_electrode_parameters = {
 
 # Run simulation, electrode object argument in cell.simulate
 print("running simulation...")
-cell.simulate(rec_imem=True,rec_isyn=True)
+cell.simulate(rec_imem=True)
 
 # Create electrode objects
 grid_electrode = LFPy.RecExtElectrode(cell,**grid_electrode_parameters)

--- a/examples/example3.py
+++ b/examples/example3.py
@@ -134,7 +134,7 @@ for i_syn in range(n_synapses):
     synapse.set_spike_times(pre_syn_sptimes[pre_syn_pick[i_syn]])
 
 #run the cell simulation
-cell.simulate(rec_imem=True,rec_isyn=True)
+cell.simulate(rec_imem=True)
 
 #set up the extracellular device
 point_electrode = LFPy.RecExtElectrode(cell, **point_electrode_parameters)

--- a/examples/example4.py
+++ b/examples/example4.py
@@ -63,7 +63,7 @@ electrode = LFPy.RecExtElectrode(**electrode_parameters)
 
 # Run simulation, electrode object argument in cell.simulate
 print("running simulation...")
-cell.simulate(electrode=electrode, rec_isyn=True)
+cell.simulate(electrode=electrode)
 print("done")
 
 #create a plot

--- a/examples/example5.py
+++ b/examples/example5.py
@@ -116,7 +116,7 @@ synapse = LFPy.Synapse(cell, **synapseParameters)
 synapse.set_spike_times(np.array([1]))
 
 #perform NEURON simulation, results saved as attributes in the cell instance
-cell.simulate(electrode = electrode, rec_isyn=True)
+cell.simulate(electrode = electrode)
 
 # Plotting of simulation results:
 from example_suppl import plot_ex2

--- a/examples/example6.py
+++ b/examples/example6.py
@@ -310,7 +310,6 @@ electrodeParameters = {
 # Parameters for the cell.simulate() call, recording membrane- and syn.-currents
 simulationParameters = {
     'rec_imem' : True,  # Record Membrane currents during simulation
-    'rec_isyn' : True,  # Record synaptic currents
 }
 
 ################################################################################

--- a/examples/example7.py
+++ b/examples/example7.py
@@ -143,7 +143,6 @@ electrodeParameters = {
 # Parameters for the cell.simulate() call, recording membrane- and syn.-currents
 simulationParameters = {
     'rec_imem' : True,  # Record Membrane currents during simulation
-    'rec_isyn' : True,  # Record synaptic currents
 }
 
 ################################################################################

--- a/examples/example8.py
+++ b/examples/example8.py
@@ -142,7 +142,6 @@ electrodeParameters = {
 # Parameters for the cell.simulate() call, recording membrane- and syn.-currents
 simulationParameters = {
     'rec_imem' : True,  # Record Membrane currents during simulation
-    'rec_isyn' : True,  # Record synaptic currents
 }
 
 ################################################################################

--- a/examples/example_EPFL_neurons.py
+++ b/examples/example_EPFL_neurons.py
@@ -43,10 +43,10 @@ neuron.h.load_file("stdrun.hoc")
 neuron.h.load_file("import3d.hoc")
 
 #load only some layer 5 pyramidal cell types
-neurons = glob(os.path.join('hoc_combos_syn.1_0_10.allzips', 'L5_TTPC*'))
-neurons += glob(os.path.join('hoc_combos_syn.1_0_10.allzips', 'L5_MC*'))[:8]
-neurons += glob(os.path.join('hoc_combos_syn.1_0_10.allzips', 'L5_LBC*'))[:8]
-neurons += glob(os.path.join('hoc_combos_syn.1_0_10.allzips', 'L5_NBC*'))[:8]
+neurons = glob(os.path.join('hoc_combos_syn.1_0_10.allzips', 'L5_TTPC*'))[:1]
+neurons += glob(os.path.join('hoc_combos_syn.1_0_10.allzips', 'L5_MC*'))[:1]
+neurons += glob(os.path.join('hoc_combos_syn.1_0_10.allzips', 'L5_LBC*'))[:1]
+neurons += glob(os.path.join('hoc_combos_syn.1_0_10.allzips', 'L5_NBC*'))[:1]
 
 #flag for cell template file to switch on (inactive) synapses
 add_synapses = False
@@ -104,14 +104,14 @@ def get_templatename(f):
 # PARAMETERS
 
 #sim duration
-tstopms = 1000.
+tstop = 1000.
 dt = 2**-6
 
 PointProcParams = {
     'idx' : 0,
     'pptype' : 'SinSyn',
     'delay' : 200.,
-    'dur' : tstopms - 300.,
+    'dur' : tstop - 300.,
     'pkamp' : 0.5,
     'freq' : 0.,
     'phase' : np.pi/2,
@@ -181,9 +181,8 @@ for i, NRN in enumerate(neurons):
                              templatefile=os.path.join(NRN, 'template.hoc'),
                              templatename=templatename,
                              templateargs=1 if add_synapses else 0,
-                             tstopms=tstopms,
-                             timeres_NEURON=dt,
-                             timeres_python=dt,
+                             tstop=tstop,
+                             dt=dt,
                              nsegs_method=None)
         
             #set view as in most other examples
@@ -198,7 +197,7 @@ for i, NRN in enumerate(neurons):
                                              z=np.zeros(4),
                                              sigma=0.3, r=5, n=50,
                                              N=np.array([[1, 0, 0], [1, 0, 0], [1, 0, 0], [1, 0, 0]]),
-                                             method='som_as_point')
+                                             method='soma_as_point')
             
             #run simulation
             cell.simulate(electrode=electrode)

--- a/examples/example_network/example_NetworkCell.py
+++ b/examples/example_network/example_NetworkCell.py
@@ -47,7 +47,7 @@ iclamp = StimIntElectrode(
     record_current=True
     )
 # run simulation
-cell.simulate(rec_istim=iclamp.record_current)
+cell.simulate()
 
 plt.subplot(2,1,1)
 plt.plot(cell.tvec, iclamp.i)


### PR DESCRIPTION
If `record_current=True` and/or `record_potential=True` is set when creating a point process, then the corresponding device current and target potential will be recorded automatically. Fixes the corresponding bullet in Issue #14 