### PR TITLE
added class LFPy.OneSphereVolumeConductor and corresponding unittest

### DIFF
--- a/LFPy/__init__.py
+++ b/LFPy/__init__.py
@@ -41,7 +41,7 @@ from .cell import Cell
 from .templatecell import TemplateCell
 from .network import NetworkCell, NetworkPopulation, Network
 from .test import _test as run_tests
-from .eegmegcalc import FourSphereVolumeConductor, InfiniteVolumeConductor, get_current_dipole_moment, MEG
+from .eegmegcalc import OneSphereVolumeConductor, FourSphereVolumeConductor, InfiniteVolumeConductor, get_current_dipole_moment, MEG
 from . import lfpcalc
 from . import tools
 from . import inputgenerators

--- a/LFPy/cell.py
+++ b/LFPy/cell.py
@@ -752,7 +752,7 @@ class Cell(object):
         self.ymid = .5*(self.ystart+self.yend).flatten()
         self.zmid = .5*(self.zstart+self.zend).flatten()
 
-    def get_idx(self, section='allsec', z_min=-10000, z_max=10000):
+    def get_idx(self, section='allsec', z_min=-1E6, z_max=1E6):
         """Returns compartment idx of segments from sections with names that match
         the pattern defined in input section on interval [z_min, z_max].
 
@@ -818,7 +818,7 @@ class Cell(object):
         return np.argmin(dist)
 
     def get_rand_idx_area_norm(self, section='allsec', nidx=1,
-                               z_min=-10000, z_max=10000):
+                               z_min=-1E6, z_max=1E6):
         """Return nidx segment indices in section with random probability
         normalized to the membrane area of segment on
         interval [z_min, z_max]

--- a/LFPy/test/test_eegmegcalc.py
+++ b/LFPy/test/test_eegmegcalc.py
@@ -202,7 +202,7 @@ class testOneSphereVolumeConductor(unittest.TestCase):
     """
     test class OneSphereVolumeConductor
     """
-    def test_OneSphereVolumeConductor_0(self):
+    def test_OneSphereVolumeConductor_00(self):
         """test case where sigma_i == sigma_o which
         should be identical to the standard point-source potential in
         infinite homogeneous media
@@ -222,8 +222,8 @@ class testOneSphereVolumeConductor(unittest.TestCase):
         r = np.array([radius, theta, phi])
         
         # predict potential
-        sphere = LFPy.OneSphereVolumeConductor(r=r, rs=rs, R=R, sigma_i=sigma, sigma_o=sigma)
-        phi = sphere.calc_potential(I)
+        sphere = LFPy.OneSphereVolumeConductor(r=r, R=R, sigma_i=sigma, sigma_o=sigma)
+        phi = sphere.calc_potential(rs=rs, I=I)
         
         # ground truth
         phi_gt = I / (4*np.pi*sigma*abs(radius-rs))
@@ -231,6 +231,34 @@ class testOneSphereVolumeConductor(unittest.TestCase):
         # test
         np.testing.assert_almost_equal(phi, phi_gt)
 
+    def test_OneSphereVolumeConductor_01(self):
+        """test case where sigma_i == sigma_o which
+        should be identical to the standard point-source potential in
+        infinite homogeneous media
+        """
+        # current magnitude
+        I = np.ones(10)
+        # conductivity
+        sigma = 0.3 
+        # sphere radius
+        R = 1000
+        # source location (along x-axis)
+        rs = 800
+        # sphere coordinates of observation points
+        radius = np.r_[np.arange(0, rs), np.arange(rs+1, rs*2)]
+        theta = np.zeros(radius.shape)
+        phi = np.zeros(radius.shape)
+        r = np.array([radius, theta, phi])
+        
+        # predict potential
+        sphere = LFPy.OneSphereVolumeConductor(r=r, R=R, sigma_i=sigma, sigma_o=sigma)
+        phi = sphere.calc_potential(rs=rs, I=I)
+        
+        # ground truth
+        phi_gt = I[0] / (4*np.pi*sigma*abs(radius-rs))
+        
+        # test
+        np.testing.assert_almost_equal(phi, np.array([phi_gt]*I.size).T)
 
 ######## Functions used by tests: ##############################################
 

--- a/LFPy/test/test_eegmegcalc.py
+++ b/LFPy/test/test_eegmegcalc.py
@@ -198,6 +198,40 @@ class testInfiniteVolumeConductor(unittest.TestCase):
         np.testing.assert_allclose(phi, np.array([[1., 0.], [0., 1.]]))
 
 
+class testOneSphereVolumeConductor(unittest.TestCase):
+    """
+    test class OneSphereVolumeConductor
+    """
+    def test_OneSphereVolumeConductor_0(self):
+        """test case where sigma_i == sigma_o which
+        should be identical to the standard point-source potential in
+        infinite homogeneous media
+        """
+        # current magnitude
+        I = 1.
+        # conductivity
+        sigma = 0.3 
+        # sphere radius
+        R = 1000
+        # source location (along x-axis)
+        rs = 800
+        # sphere coordinates of observation points
+        radius = np.r_[np.arange(0, rs), np.arange(rs+1, rs*2)]
+        theta = np.zeros(radius.shape)
+        phi = np.zeros(radius.shape)
+        r = np.array([radius, theta, phi])
+        
+        # predict potential
+        sphere = LFPy.OneSphereVolumeConductor(r=r, rs=rs, R=R, sigma_i=sigma, sigma_o=sigma)
+        phi = sphere.calc_potential(I)
+        
+        # ground truth
+        phi_gt = I / (4*np.pi*sigma*abs(radius-rs))
+        
+        # test
+        np.testing.assert_almost_equal(phi, phi_gt)
+
+
 ######## Functions used by tests: ##############################################
 
 def make_class_object(rz1, r_el):


### PR DESCRIPTION
Addresses bullet point in Issue #7 on incorporation calculation of electric potential of point sources embedded in a spherical volume-conductor embedded in infinite homogeneous conductive media. Based on a description in Deng, Journal of Electrostatics 66 (2008) 549–560. 

Notes:
- computes potentials only for a single current source but for an arbitrary number of measurement locations
- observation points implemented in spherical coordinates 
- source must be put along the horizontal x-axis
- current must be scalar
- lacks functionality to predict potentials from LFPy.Cell like objects