### PR TITLE
Allows Network.simulate(to_file=True)

### DIFF
--- a/LFPy/network.py
+++ b/LFPy/network.py
@@ -811,7 +811,8 @@ class Network(object):
                  rec_current_dipole_moment=False,
                  rec_pop_contributions=False,
                  rec_variables=[], variable_dt=False, atol=0.001,
-                 to_memory=True, to_file=False, file_name=None,
+                 to_memory=True, to_file=False,
+                 file_name='OUTPUT.h5',
                  dotprodcoeffs=None, **kwargs):
         """
         This is the main function running the simulation of the network model.
@@ -847,7 +848,10 @@ class Network(object):
         atol:       absolute tolerance used with NEURON variable timestep
         to_memory:  only valid with electrode, store lfp in -> electrode.LFP
         to_file:    only valid with electrode, save LFPs in hdf5 file format
-        file_name:  name of hdf5 file, '.h5' is appended if it doesnt exist
+        file_name : str
+            If to_file is True, file which extracellular potentials will be
+            written to. The file format is HDF5, default is "OUTPUT.h5", put
+            in folder Network.OUTPUTPATH
         dotprodcoeffs :  list of N x Nseg ndarray. These arrays will at
                     every timestep be multiplied by the membrane currents.
                     Presumably useful for memory efficient csd or lfp calcs
@@ -903,7 +907,7 @@ class Network(object):
                     cell._set_variable_recorders(rec_variables)
 
         #run fadvance until t >= tstop, and calculate LFP if asked for
-        if electrode is None and dotprodcoeffs is None and not rec_current_dipole_moment and not rec_pop_contributions:
+        if electrode is None and dotprodcoeffs is None and not rec_current_dipole_moment and not rec_pop_contributions and not to_file:
             if not rec_imem:
                 if self.verbose:
                     print("rec_imem = {}, not recording membrane currents!".format(rec_imem))
@@ -917,7 +921,7 @@ class Network(object):
                             atol=atol,
                             to_memory=to_memory,
                             to_file=to_file,
-                            file_name=file_name,
+                            file_name='tmp_output_RANK_{:03d}.h5',
                             dotprodcoeffs=dotprodcoeffs,
                             rec_current_dipole_moment=rec_current_dipole_moment,
                             rec_pop_contributions=rec_pop_contributions,
@@ -968,14 +972,32 @@ class Network(object):
                     dest=0, tag=13)
                 COMM.send([x for x in self.populations[name].gids],
                     dest=0, tag=14)
+        
+        # create final output file, summing up single rank output.
+        if to_file and electrode is not None:
+            f = h5py.File(os.path.join(self.OUTPUTPATH, file_name), 'w')
+            for i in range(SIZE):
+                fname = os.path.join(self.OUTPUTPATH, 'tmp_output_RANK_{:03d}.h5'.format(i))
+                f0 = h5py.File(fname, 'r')
+                if i == 0:
+                    for key, val in f0.items():
+                        f[key] = val.value
+                else:
+                    for key, val in f0.items():
+                        f[key] += val
+            f.close()            
+
+
 
         if electrode is None and dotprodcoeffs is None and not rec_current_dipole_moment and not rec_pop_contributions:
             return dict(times=times, gids=gids)
         else:
             # communicate and sum up LFPs and dipole moments:
-            for i in range(len(LFP)):
-                LFP[i] = ReduceStructArray(LFP[i])
-            P = ReduceStructArray(P)
+            if LFP is not None:
+                for i in range(len(LFP)):
+                    LFP[i] = ReduceStructArray(LFP[i])
+            if P is not None:
+                P = ReduceStructArray(P)
             return dict(times=times, gids=gids), LFP, P
 
 
@@ -1121,11 +1143,13 @@ def _run_simulation_with_electrode(network, cvode,
     to_memory : bool
         Boolean flag for computing extracellular potentials, default is True
     to_file : bool or None
-        Boolean flag for computing extracellular potentials to file <file_name>,
-        default is False
-    file_name : str
-        If to_file is True, file which extracellular potentials will be written
-        to. The file format is HDF5
+        Boolean flag for computing extracellular potentials to file
+        <OUTPUTPATH/file_name>, default is False
+    file_name : formattable str
+        If to_file is True, file which extracellular potentials will be
+        written to. The file format is HDF5, default is
+        "output_RANK_{:03d}.h5". The output is written per RANK, and the
+        RANK # will be inserted into the corresponding file name. 
     dotprodcoeffs : None or list of ndarrays
         Each element in list is a mapping of transmembrane currents to a measure
         on the form :math:`V = \mathbf{C} \cdot \mathbf{I}`
@@ -1163,13 +1187,13 @@ def _run_simulation_with_electrode(network, cvode,
 
 
     """
-    try:
-        import h5py
-    except ImportError:
-        print('h5py not installed, LFP to file not possible')
-        to_file = False
-        file_name = None
 
+    # create a dummycell object lumping together needed attributes
+    # for calculation of extracellular potentials etc. The population_nsegs
+    # array is used to slice indices such that single-population
+    # contributions to the potential can be calculated.
+    population_nsegs, network_dummycell = network._create_network_dummycell()
+    
     # Use electrode object(s) to calculate coefficient matrices for LFP
     # calculations. If electrode is a list, then
     # put electrodecoeff in a list, if it isn't already
@@ -1196,11 +1220,11 @@ def _run_simulation_with_electrode(network, cvode,
         # V_r(r, t_i) = G x I(r, t_i)
 
 
-        # create a dummycell object lumping together needed attributes
-        # for calculation of extracellular potentials. The population_nsegs
-        # array is used to slice indices such that single-population
-        # contributions to the potential can be calculated.
-        population_nsegs, network_dummycell = network._create_network_dummycell()
+        # # create a dummycell object lumping together needed attributes
+        # # for calculation of extracellular potentials. The population_nsegs
+        # # array is used to slice indices such that single-population
+        # # contributions to the potential can be calculated.
+        # population_nsegs, network_dummycell = network._create_network_dummycell()
 
         # We can have a number of separate electrode objects in a list, create
         # mappings for each
@@ -1213,8 +1237,11 @@ def _run_simulation_with_electrode(network, cvode,
 
     elif electrode is None:
         electrodes = None
-        if rec_current_dipole_moment:
-            population_nsegs, network_dummycell = network._create_network_dummycell()
+        # if rec_current_dipole_moment:
+        #     population_nsegs, network_dummycell = network._create_network_dummycell()
+    
+
+
 
     # set maximum integration step, it is necessary for communication of
     # spikes across RANKs to occur.
@@ -1270,28 +1297,32 @@ def _run_simulation_with_electrode(network, cvode,
     if to_memory:
         RESULTS = []
         for coeffs in dotprodcoeffs:
-            RESULTS.append(np.zeros((coeffs.shape[0], int(network.tstop / network.dt) + 1), dtype=dtype))
+            RESULTS.append(np.zeros((coeffs.shape[0],
+                                     int(network.tstop / network.dt) + 1),
+                                    dtype=dtype)
+                           )
+    else:
+        RESULTS = None
 
     # container for electric current dipole moment for the individual
     # populations captured inside the DummyCell instance
     if rec_current_dipole_moment:
         DIPOLE_MOMENT = np.zeros((int(network.tstop / network.dt) + 1, 3),
-            dtype=list(zip(network.population_names, [np.float]*len(network.population_names))))
+            dtype=list(zip(network.population_names,
+                           [np.float]*len(network.population_names))))
     else:
         DIPOLE_MOMENT = None
 
     #LFPs for each electrode will be put here during simulations
     if to_file:
-        raise NotImplementedError('to_file arg implementation not yet tested')
         #ensure right ending:
         if file_name.split('.')[-1] != 'h5':
             file_name += '.h5'
-        el_LFP_file = h5py.File(file_name, 'w')
-        i = 0
-        for coeffs in dotprodcoeffs:
-            el_LFP_file['electrode{:03d}'.format(i)] = np.zeros((coeffs.shape[0],
-                                int(cell.tstop / cell.dt + 1)))
-            i += 1
+        outputfile = h5py.File(os.path.join(network.OUTPUTPATH,
+                                            file_name.format(RANK)), 'w')
+        for i, coeffs in enumerate(dotprodcoeffs):
+            outputfile['OUTPUT[{:03d}]'.format(i)] = np.zeros((coeffs.shape[0],
+                                int(cell.tstop / cell.dt + 1)), dtype=dtype)
 
     # temp vector to store membrane currents at each timestep:
     imem = np.zeros(network_dummycell.totnsegs, dtype=dtype)
@@ -1299,7 +1330,9 @@ def _run_simulation_with_electrode(network, cvode,
     # create a 2D array representation of segment midpoints for dot product
     # with transmembrane currents when computing dipole moment
     if rec_current_dipole_moment:
-        midpoints = np.c_[network_dummycell.xmid, network_dummycell.ymid, network_dummycell.zmid]
+        midpoints = np.c_[network_dummycell.xmid,
+                          network_dummycell.ymid,
+                          network_dummycell.zmid]
 
     #run fadvance until time limit, and calculate LFPs for each timestep
     tstep = 0
@@ -1329,6 +1362,14 @@ def _run_simulation_with_electrode(network, cvode,
 
                 totnsegs += cell.totnsegs
 
+            if rec_current_dipole_moment:
+                k = 0 # counter
+                for nsegs, name in zip(population_nsegs, network.population_names):
+                    cellinds = np.arange(k, k+nsegs)
+                    DIPOLE_MOMENT[name][tstep, ] = np.dot(imem['imem'][cellinds, ],
+                                                          midpoints[cellinds, ])
+                    k += nsegs
+
             if to_memory:
                 for j, coeffs in enumerate(dotprodcoeffs):
                     RESULTS[j]['imem'][:, tstep] = np.dot(coeffs, imem['imem'])
@@ -1339,24 +1380,41 @@ def _run_simulation_with_electrode(network, cvode,
                     if use_isyn:
                         RESULTS[j]['isyn_e'][:, tstep] = np.dot(coeffs, imem['isyn_e'])
                         RESULTS[j]['isyn_i'][:, tstep] = np.dot(coeffs, imem['isyn_i'])
-                if rec_current_dipole_moment:
-                    k = 0 # counter
-                    for nsegs, name in zip(population_nsegs, network.population_names):
-                        cellinds = np.arange(k, k+nsegs)
-                        DIPOLE_MOMENT[name][tstep, ] = np.dot(imem['imem'][cellinds, ], midpoints[cellinds, ])
-                        k += nsegs
 
                 if rec_pop_contributions:
                     k = 0 # counter
                     for nsegs, name in zip(population_nsegs, network.population_names):
                         cellinds = np.arange(k, k+nsegs)
-                        RESULTS[j][name][:, tstep] = np.dot(coeffs[:, cellinds], imem['imem'][cellinds, ])
+                        RESULTS[j][name][:, tstep] = np.dot(coeffs[:, cellinds],
+                                                            imem['imem'][cellinds, ])
                         k += nsegs
 
             if to_file:
                 for j, coeffs in enumerate(dotprodcoeffs):
-                    el_LFP_file['electrode{:03d}'.format(j)
-                                ][:, tstep] = np.dot(coeffs, imem['imem'])
+                    outputfile['OUTPUT[{:03d}]'.format(j)
+                               ][:, tstep] = np.dot(coeffs, imem['imem'])
+                    outputfile['OUTPUT[{:03d}]'.format(j)
+                               ]['imem'][:, tstep] = np.dot(coeffs, imem['imem'])
+                    if use_ipas:
+                        outputfile['OUTPUT[{:03d}]'.format(j)
+                                   ]['ipas'][:, tstep] = np.dot(coeffs, imem['ipas'] * network_dummycell.area * 1E-2)
+                    if use_icap:
+                        outputfile['OUTPUT[{:03d}]'.format(j)
+                                   ]['icap'][:, tstep] = np.dot(coeffs, imem['icap'] * network_dummycell.area * 1E-2)
+                    if use_isyn:
+                        outputfile['OUTPUT[{:03d}]'.format(j)
+                                   ]['isyn_e'][:, tstep] = np.dot(coeffs, imem['isyn_e'])
+                        outputfile['OUTPUT[{:03d}]'.format(j)
+                                   ]['isyn_i'][:, tstep] = np.dot(coeffs, imem['isyn_i'])
+
+                if rec_pop_contributions:
+                    k = 0 # counter
+                    for nsegs, name in zip(population_nsegs, network.population_names):
+                        cellinds = np.arange(k, k+nsegs)
+                        outputfile['OUTPUT[{:03d}]'.format(j)
+                                   ][name][:, tstep] = np.dot(coeffs[:, cellinds],
+                                                              imem['imem'][cellinds, ])
+                        k += nsegs
 
             tstep += 1
         neuron.h.fadvance()
@@ -1391,6 +1449,13 @@ def _run_simulation_with_electrode(network, cvode,
 
             totnsegs += cell.totnsegs
 
+        if rec_current_dipole_moment:
+            k = 0 # counter
+            for nsegs, name in zip(population_nsegs, network.population_names):
+                cellinds = np.arange(k, k+nsegs)
+                DIPOLE_MOMENT[name][tstep, ] = np.dot(imem['imem'][cellinds, ], midpoints[cellinds, ])
+                k += nsegs
+
         if to_memory:
             for j, coeffs in enumerate(dotprodcoeffs):
                 RESULTS[j]['imem'][:, tstep] = np.dot(coeffs, imem['imem'])
@@ -1401,12 +1466,6 @@ def _run_simulation_with_electrode(network, cvode,
                 if use_isyn:
                     RESULTS[j]['isyn_e'][:, tstep] = np.dot(coeffs, imem['isyn_e'])
                     RESULTS[j]['isyn_i'][:, tstep] = np.dot(coeffs, imem['isyn_i'])
-            if rec_current_dipole_moment:
-                k = 0 # counter
-                for nsegs, name in zip(population_nsegs, network.population_names):
-                    cellinds = np.arange(k, k+nsegs)
-                    DIPOLE_MOMENT[name][tstep, ] = np.dot(imem['imem'][cellinds, ], midpoints[cellinds, ])
-                    k += nsegs
 
             if rec_pop_contributions:
                 k = 0 # counter
@@ -1418,22 +1477,43 @@ def _run_simulation_with_electrode(network, cvode,
 
         if to_file:
             for j, coeffs in enumerate(dotprodcoeffs):
-                el_LFP_file['electrode{:03d}'.format(j)
-                            ][:, tstep] = np.dot(coeffs, imem['imem'])
+                outputfile['OUTPUT[{:03d}]'.format(j)
+                           ][:, tstep] = np.dot(coeffs, imem['imem'])
+                outputfile['OUTPUT[{:03d}]'.format(j)
+                           ]['imem'][:, tstep] = np.dot(coeffs, imem['imem'])
+                if use_ipas:
+                    outputfile['OUTPUT[{:03d}]'.format(j)
+                               ]['ipas'][:, tstep] = np.dot(coeffs, imem['ipas'] * network_dummycell.area * 1E-2)
+                if use_icap:
+                    outputfile['OUTPUT[{:03d}]'.format(j)
+                               ]['icap'][:, tstep] = np.dot(coeffs, imem['icap'] * network_dummycell.area * 1E-2)
+                if use_isyn:
+                    outputfile['OUTPUT[{:03d}]'.format(j)
+                               ]['isyn_e'][:, tstep] = np.dot(coeffs, imem['isyn_e'])
+                    outputfile['OUTPUT[{:03d}]'.format(j)
+                               ]['isyn_i'][:, tstep] = np.dot(coeffs, imem['isyn_i'])
+
+            if rec_pop_contributions:
+                k = 0 # counter
+                for nsegs, name in zip(population_nsegs, network.population_names):
+                    cellinds = np.arange(k, k+nsegs)
+                    outputfile['OUTPUT[{:03d}]'.format(j)
+                               ][name][:, tstep] = np.dot(coeffs[:, cellinds],
+                                                          imem['imem'][cellinds, ])
+                    k += nsegs
+
+
 
     except IndexError:
         pass
 
 
-    # Final step, put LFPs in the electrode object, superimpose if necessary
-    # If electrode.perCellLFP, store individual LFPs
     if to_memory:
-        # return the electrode.LFP
         return RESULTS, DIPOLE_MOMENT
 
     if to_file:
-        el_LFP_file.close()
-        return
+        outputfile.close()
+        return RESULTS, DIPOLE_MOMENT
 
 
 def ReduceStructArray(sendbuf, op=MPI.SUM):

--- a/LFPy/test/test_network.py
+++ b/LFPy/test/test_network.py
@@ -20,6 +20,7 @@ import unittest
 import numpy as np
 import LFPy
 import neuron
+import h5py
 
 class testNetworkPopulation(unittest.TestCase):
     """
@@ -269,3 +270,90 @@ class testNetwork(unittest.TestCase):
         network.pc.gid_clear()
         os.system('rm -r tmp_testNetworkPopulation')
         neuron.h('forall delete_section()')
+
+
+
+
+    def test_Network_03(self):
+        cellParameters = dict(
+            morphology=os.path.join(LFPy.__path__[0], 'test', 'ball_and_sticks_w_lists.hoc'),
+            templatefile=os.path.join(LFPy.__path__[0], 'test', 'ball_and_stick_template.hoc'),
+            templatename='ball_and_stick_template',
+            templateargs=None,
+            passive=False,
+            dt=2**-3,
+            tstop=100,
+            delete_sections=False,
+        )
+
+        populationParameters = dict(
+            CWD=None,
+            CELLPATH=None,
+            Cell=LFPy.NetworkCell,
+            cell_args = cellParameters,
+            pop_args = dict(
+                radius=100,
+                loc=0.,
+                scale=20.),
+            rotation_args = dict(x=0, y=0),
+            POP_SIZE = 4,
+            name = 'test',
+        )
+        networkParameters = dict(
+            dt=2**-3,
+            tstart=0.,
+            tstop=100.,
+            v_init=-65.,
+            celsius=6.3,
+            OUTPUTPATH='tmp_testNetworkPopulation'
+            )
+        electrodeParameters = dict(
+            sigma=0.3,
+            x = np.arange(10)*100,
+            y = np.arange(10)*100,
+            z = np.arange(10)*100
+        )
+        # set up
+        network = LFPy.Network(**networkParameters)
+        network.create_population(**populationParameters)
+        connectivity = network.get_connectivity_rand(pre='test', post='test', connprob=0.5)
+
+        # test set up
+        for population in network.populations.values():
+            self.assertTrue(len(population.cells) == population.POP_SIZE)
+            for cell, soma_pos, gid in zip(population.cells, population.soma_pos, population.gids):
+                self.assertTrue(type(cell) is LFPy.NetworkCell)
+                self.assertTrue((cell.somapos[0] == soma_pos['x']) &
+                                (cell.somapos[1] == soma_pos['y']) &
+                                (cell.somapos[2] == soma_pos['z']))
+                self.assertEqual(cell.gid, gid)
+                self.assertTrue(np.sqrt(soma_pos['x']**2 + soma_pos['y']**2) <= 100.)
+            np.testing.assert_equal(population.gids, np.arange(4))
+
+        np.testing.assert_equal(connectivity.shape, (population.POP_SIZE, population.POP_SIZE))
+        np.testing.assert_equal(connectivity.diagonal(), np.zeros(population.POP_SIZE))
+
+        # set up electrode
+        electrode = LFPy.RecExtElectrode(**electrodeParameters)
+
+        # connect and run sim
+        network.connect(pre='test', post='test', connectivity=connectivity)
+        network.simulate(electrode=electrode, to_file=True, to_memory=False,
+                         file_name='OUTPUT.h5')
+
+        # test output
+        for population in network.populations.values():
+            for cell in population.cells:
+                self.assertTrue(np.all(cell.somav == network.v_init))
+            
+        f0 = h5py.File(os.path.join(network.OUTPUTPATH, 'tmp_output_RANK_000.h5'), 'r')
+        f1 = h5py.File(os.path.join(network.OUTPUTPATH, 'OUTPUT.h5'), 'r')        
+        np.testing.assert_equal(f0['OUTPUT[000]'].value, f1['OUTPUT[000]'].value)
+        f0.close()
+        f1.close()
+
+
+        network.pc.gid_clear()
+        os.system('rm -r tmp_testNetworkPopulation')
+        neuron.h('forall delete_section()')
+

--- a/LFPy/test/test_network.py
+++ b/LFPy/test/test_network.py
@@ -346,14 +346,98 @@ class testNetwork(unittest.TestCase):
             for cell in population.cells:
                 self.assertTrue(np.all(cell.somav == network.v_init))
             
-        f0 = h5py.File(os.path.join(network.OUTPUTPATH, 'tmp_output_RANK_000.h5'), 'r')
-        f1 = h5py.File(os.path.join(network.OUTPUTPATH, 'OUTPUT.h5'), 'r')        
-        np.testing.assert_equal(f0['OUTPUT[000]'].value, f1['OUTPUT[000]'].value)
-        f0.close()
-        f1.close()
+        f = h5py.File(os.path.join(network.OUTPUTPATH, 'OUTPUT.h5'), 'r')        
+        np.testing.assert_equal(f['OUTPUT[0]'].value, np.zeros_like(f['OUTPUT[0]'].value))
+        f.close()
 
 
         network.pc.gid_clear()
         os.system('rm -r tmp_testNetworkPopulation')
         neuron.h('forall delete_section()')
 
+
+    def test_Network_04(self):
+        cellParameters = dict(
+            morphology=os.path.join(LFPy.__path__[0], 'test', 'ball_and_sticks_w_lists.hoc'),
+            templatefile=os.path.join(LFPy.__path__[0], 'test', 'ball_and_stick_template.hoc'),
+            templatename='ball_and_stick_template',
+            templateargs=None,
+            passive=False,
+            dt=2**-3,
+            tstop=100,
+            delete_sections=False,
+        )
+
+        populationParameters = dict(
+            CWD=None,
+            CELLPATH=None,
+            Cell=LFPy.NetworkCell,
+            cell_args = cellParameters,
+            pop_args = dict(
+                radius=100,
+                loc=0.,
+                scale=20.),
+            rotation_args = dict(x=0, y=0),
+            POP_SIZE = 4,
+            name = 'test',
+        )
+        networkParameters = dict(
+            dt=2**-3,
+            tstart=0.,
+            tstop=100.,
+            v_init=-65.,
+            celsius=6.3,
+            OUTPUTPATH='tmp_testNetworkPopulation'
+            )
+        electrodeParameters = dict(
+            sigma=0.3,
+            x = np.arange(10)*100,
+            y = np.arange(10)*100,
+            z = np.arange(10)*100
+        )
+        # set up
+        network = LFPy.Network(**networkParameters)
+        network.create_population(**populationParameters)
+        connectivity = network.get_connectivity_rand(pre='test', post='test',
+                                                     connprob=0.5)
+
+        # test set up
+        for population in network.populations.values():
+            self.assertTrue(len(population.cells) == population.POP_SIZE)
+            for cell, soma_pos, gid in zip(population.cells,
+                                           population.soma_pos,
+                                           population.gids):
+                self.assertTrue(type(cell) is LFPy.NetworkCell)
+                self.assertTrue((cell.somapos[0] == soma_pos['x']) &
+                                (cell.somapos[1] == soma_pos['y']) &
+                                (cell.somapos[2] == soma_pos['z']))
+                self.assertEqual(cell.gid, gid)
+                self.assertTrue(np.sqrt(soma_pos['x']**2 + soma_pos['y']**2) <= 100.)
+            np.testing.assert_equal(population.gids, np.arange(4))
+
+        np.testing.assert_equal(connectivity.shape,
+                                (population.POP_SIZE, population.POP_SIZE))
+        np.testing.assert_equal(connectivity.diagonal(),
+                                np.zeros(population.POP_SIZE))
+
+        # set up electrode
+        electrode = LFPy.RecExtElectrode(**electrodeParameters)
+
+        # connect and run sim
+        network.connect(pre='test', post='test', connectivity=connectivity)
+        SPIKES, RESULTS, P = network.simulate(electrode=electrode, to_file=True,
+                                      to_memory=True, file_name='OUTPUT.h5')
+
+        # test output
+        for population in network.populations.values():
+            for cell in population.cells:
+                self.assertTrue(np.all(cell.somav == network.v_init))
+            
+        f = h5py.File(os.path.join(network.OUTPUTPATH, 'OUTPUT.h5'), 'r')        
+        np.testing.assert_equal(f['OUTPUT[0]'].value, RESULTS[0])
+        f.close()
+
+
+        network.pc.gid_clear()
+        os.system('rm -r tmp_testNetworkPopulation')
+        neuron.h('forall delete_section()')

--- a/examples/example_network/example_Network.py
+++ b/examples/example_network/example_Network.py
@@ -229,6 +229,8 @@ electrodeParameters = dict(
 networkSimulationArguments = dict(
     rec_current_dipole_moment = True,
     rec_pop_contributions = True,
+    to_memory = True,
+    to_file = False
 )
 
 # populations and connection probability
@@ -323,7 +325,6 @@ if __name__ == '__main__':
         electrode=electrode,
         **networkSimulationArguments
     )
-
 
     # collect somatic potentials across all RANKs to RANK 0
     if RANK == 0:


### PR DESCRIPTION
Implements simulation to disk for extracellular potentials but not dipole moments or spikes (which are less memory demanding). 

Addresses the corresponding point in #14