### PR TITLE
added Cell.distort_geometry method

### DIFF
--- a/LFPy/cell.py
+++ b/LFPy/cell.py
@@ -2345,12 +2345,17 @@ class Cell(object):
         return iseg, ipar
 
 
-    def distort_geometry(self, factor=0., axis='z', nu=0.5):
+    def distort_geometry(self, factor=0., axis='z', nu=0.0):
         """
         Distorts cellular morphology with a relative factor along a chosen axis
         preserving Poisson's ratio. A ratio nu=0.5 assumes uncompressible and
-        isotropic media. This method does not affect the underlying cable
-        properties, only predictions of extracellular measurements.
+        isotropic media that embeds the cell. A ratio nu=0 will only affect
+        geometry along the chosen axis. A ratio nu=-1 will isometrically scale
+        the neuron geometry along each axis.
+        
+        This method does not affect the underlying cable properties of the cell,
+        only predictions of extracellular measurements (by affecting the
+        relative locations of sources representing the compartments).
         
         Parameters
         ----------
@@ -2362,7 +2367,7 @@ class Cell(object):
             which axis to apply compression/stretching. Default is "z".
         nu : float
             Poisson's ratio. Ratio between axial and transversal
-            compression/stretching. Default is 0.5.
+            compression/stretching. Default is 0.
         """
         try:
             assert(abs(factor) < 1.)

--- a/LFPy/cell.py
+++ b/LFPy/cell.py
@@ -2343,3 +2343,57 @@ class Cell(object):
             ipar = iseg
 
         return iseg, ipar
+
+
+    def distort_geometry(self, factor=0., axis='z', nu=0.5):
+        """
+        Distorts cellular morphology with a relative factor along a chosen axis
+        preserving Poisson's ratio. A ratio nu=0.5 assumes uncompressible and
+        isotropic media. This method does not affect the underlying cable
+        properties, only predictions of extracellular measurements.
+        
+        Parameters
+        ----------
+        factor : float
+            relative compression/stretching factor of morphology. Default is 0
+            (no compression/stretching). Positive values implies a compression
+            along the chosen axis.
+        axis : str
+            which axis to apply compression/stretching. Default is "z".
+        nu : float
+            Poisson's ratio. Ratio between axial and transversal
+            compression/stretching. Default is 0.5.
+        """
+        try:
+            assert(abs(factor) < 1.)
+        except AssertionError:
+            raise AssertionError('abs(factor) >= 1, factor must be in <-1, 1>')
+        try:
+            assert(axis in ['x', 'y', 'z'])
+        except AssertionError:
+            raise AssertionError('axis={} not "x", "y" or "z"'.format(axis))
+        
+        for pos, dir_ in zip(self.somapos, 'xyz'):
+            geometry = np.c_[getattr(self, dir_+'start'),
+                             getattr(self, dir_+'mid'),
+                             getattr(self, dir_+'end')]
+            if dir_ == axis:
+                geometry -= pos
+                geometry *= (1. - factor)
+                geometry += pos
+            else:
+                geometry -= pos
+                geometry *= (1. + factor*nu)
+                geometry += pos
+            
+            setattr(self, dir_+'start', geometry[:, 0])
+            setattr(self, dir_+'mid', geometry[:, 1])
+            setattr(self, dir_+'end', geometry[:, 2])
+        
+        # recompute length of each segment
+        self.length = np.sqrt((self.xend - self.xstart)**2 +
+                              (self.yend - self.ystart)**2 +
+                              (self.zend - self.zstart)**2)
+    
+    
+    

--- a/LFPy/recextelectrode.py
+++ b/LFPy/recextelectrode.py
@@ -744,11 +744,8 @@ class RecMEAElectrode(RecExtElectrode):
         """Will squeeze self.cell centered around the soma by a scaling factor,
         so that it fits inside the slice. If scaling factor is not big enough,
         a RuntimeError is raised. """
-
-        zpos = self.cell.zmid[0]
-        self.cell.zmid = (self.cell.zmid - zpos) * self.squeeze_cell_factor + zpos
-        self.cell.zstart = (self.cell.zstart - zpos) * self.squeeze_cell_factor + zpos
-        self.cell.zend = (self.cell.zend - zpos) * self.squeeze_cell_factor + zpos
+        
+        self.cell.distort_geometry(factor=self.squeeze_cell_factor)
 
         if (np.max([self.cell.zstart, self.cell.zend]) > self.h + self.z_shift or
             np.min([self.cell.zstart, self.cell.zend]) < self.z_shif):

--- a/LFPy/test/test_cell.py
+++ b/LFPy/test/test_cell.py
@@ -1205,6 +1205,25 @@ class testCell(unittest.TestCase):
         np.testing.assert_allclose(electrode.LFP, electrode1.LFP)
 
 
+    def test_cell_distort_geometry_01(self):
+        cell0 = LFPy.Cell(morphology=os.path.join(LFPy.__path__[0], 'test',
+                                          'ball_and_sticks.hoc' ))
+        factors = [-0.2, 0.1, 0., 0.1, 0.2]
+        nus = [-0.5, 0., 0.5]
+        for factor in factors:
+            for nu in nus:
+                for axis in 'xyz':
+                    cell1 = LFPy.Cell(morphology=os.path.join(LFPy.__path__[0],
+                                                      'test',
+                                                      'ball_and_sticks.hoc' ))
+                    cell1.distort_geometry(factor=factor, nu=nu, axis=axis)
+                    for attr in ['start', 'mid', 'end']:
+                        for ax in 'xyz'.replace(axis, ''):
+                            np.testing.assert_allclose(getattr(cell0, ax+attr)*(1+factor*nu),
+                                                       getattr(cell1, ax+attr))
+                        np.testing.assert_allclose(getattr(cell0, axis+attr)*(1-factor),
+                                                   getattr(cell1, axis+attr))
+
     ######## Functions used by tests: ##########################################
 def stickSimulationTesttvec(**kwargs):
     stick = LFPy.Cell(morphology = os.path.join(LFPy.__path__[0], 'test',

--- a/LFPy/test/test_networkcell.py
+++ b/LFPy/test/test_networkcell.py
@@ -1076,6 +1076,31 @@ class testNetworkCell(unittest.TestCase):
     
         np.testing.assert_allclose(electrode.LFP, electrode1.LFP)
 
+    def test_cell_distort_geometry_01(self):
+        cell0 = LFPy.NetworkCell(morphology=os.path.join(LFPy.__path__[0], 'test',
+                                                  'ball_and_sticks_w_lists.hoc' ),
+                        templatefile=os.path.join(LFPy.__path__[0], 'test', 'ball_and_stick_template.hoc'),
+                        templatename='ball_and_stick_template',
+                        templateargs=None,
+                        )
+        factors = [-0.2, 0.1, 0., 0.1, 0.2]
+        nus = [-0.5, 0., 0.5]
+        for factor in factors:
+            for nu in nus:
+                for axis in 'xyz':
+                    cell1 = LFPy.NetworkCell(morphology=os.path.join(LFPy.__path__[0], 'test',
+                                                  'ball_and_sticks_w_lists.hoc' ),
+                        templatefile=os.path.join(LFPy.__path__[0], 'test', 'ball_and_stick_template.hoc'),
+                        templatename='ball_and_stick_template',
+                        templateargs=None,
+                        )
+                    cell1.distort_geometry(factor=factor, nu=nu, axis=axis)
+                    for attr in ['start', 'mid', 'end']:
+                        for ax in 'xyz'.replace(axis, ''):
+                            np.testing.assert_allclose(getattr(cell0, ax+attr)*(1+factor*nu),
+                                                       getattr(cell1, ax+attr))
+                        np.testing.assert_allclose(getattr(cell0, axis+attr)*(1-factor),
+                                                   getattr(cell1, axis+attr))
 
 def stickSimulationTesttvec(**kwargs):
     stick = LFPy.NetworkCell(morphology = os.path.join(LFPy.__path__[0], 'test',

--- a/LFPy/test/test_templatecell.py
+++ b/LFPy/test/test_templatecell.py
@@ -1076,6 +1076,33 @@ class testTemplateCell(unittest.TestCase):
         np.testing.assert_allclose(electrode.LFP, electrode1.LFP)
 
 
+    def test_cell_distort_geometry_01(self):
+        cell0 = LFPy.TemplateCell(morphology=os.path.join(LFPy.__path__[0], 'test',
+                                                  'ball_and_sticks_w_lists.hoc' ),
+                        templatefile=os.path.join(LFPy.__path__[0], 'test', 'ball_and_stick_template.hoc'),
+                        templatename='ball_and_stick_template',
+                        templateargs=None,
+                        )
+        factors = [-0.2, 0.1, 0., 0.1, 0.2]
+        nus = [-0.5, 0., 0.5]
+        for factor in factors:
+            for nu in nus:
+                for axis in 'xyz':
+                    cell1 = LFPy.TemplateCell(morphology=os.path.join(LFPy.__path__[0], 'test',
+                                                  'ball_and_sticks_w_lists.hoc' ),
+                        templatefile=os.path.join(LFPy.__path__[0], 'test', 'ball_and_stick_template.hoc'),
+                        templatename='ball_and_stick_template',
+                        templateargs=None,
+                        )
+                    cell1.distort_geometry(factor=factor, nu=nu, axis=axis)
+                    for attr in ['start', 'mid', 'end']:
+                        for ax in 'xyz'.replace(axis, ''):
+                            np.testing.assert_allclose(getattr(cell0, ax+attr)*(1+factor*nu),
+                                                       getattr(cell1, ax+attr))
+                        np.testing.assert_allclose(getattr(cell0, axis+attr)*(1-factor),
+                                                   getattr(cell1, axis+attr))
+
+
     ######## Functions used by tests: ##########################################
 
 def stickSimulationTesttvec(**kwargs):


### PR DESCRIPTION
I added a more generic way distorting geometries as a Cell-class method, that assumes that the morphology is embedded in an uncompressible and isotropic medium. Thus, if it is squeezed along the z-axis, it gets wider along the x- and y-axis etc. I updated also the MEA  _squeeze_cell_in_depth_direction method. Setting "nu=0" should result in identical behavior as before, but the default is nu=0.5.