### PR TITLE
lfpy.readthedocs.io is live

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ in collaboration with the Laboratory of Neuroinformatics (http://www.nencki.gov.
 Nencki Institute of Experimental Biology (http://www.nencki.gov.pl), Warsaw, Poland. The effort was supported by 
 International Neuroinformatics Coordinating Facility (http://incf.org), the Research Council of Norway (http://www.forskningsradet.no/english) (eScience, NevroNor) and EU-FP7 (BrainScaleS, http://www.brainscales.org).
 
-For updated information on LFPy and online documentation, see the LFPy homepage (http://LFPy.github.io).
+For updated information on LFPy and online documentation, see the LFPy homepage (http://lfpy.readthedocs.io).
 
 This scientific software is released under the GNU Public License GPLv3.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,6 +8,8 @@
 LFPy Homepage
 =============
 
+(Looking for the old LFPy documentation? Follow `link <https://lfpy.github.io/v1.3>`_)
+
 LFPy is a `Python <http://www.python.org>`_ package for calculation of extracellular potentials from multicompartment neuron models and recurrent networks of multicompartment neurons.
 It relies on the `NEURON simulator <http://www.neuron.yale.edu/neuron/>`_ and uses the 
 `Python interface <http://www.frontiersin.org/neuroinformatics/10.3389/neuro.11.001.2009/abstract>`_ it provides.

--- a/doc/information.rst
+++ b/doc/information.rst
@@ -20,7 +20,7 @@ The stable versions of LFPy can be accessed by listing and checking out tags, e.
     git checkout <tag name>
     
 
-To browse the documentation and source codes online, see `http://lfpy.github.io/classes.html <http://lfpy.github.io/classes.html>`_ or `https://github.com/LFPy/LFPy <https://github.com/LFPy/LFPy>`_
+To browse the documentation and source codes online, see `http://lfpy.readthedocs.io/classes.html <http://lfpy.readthedocs.io/classes.html>`_ or `https://github.com/LFPy/LFPy <https://github.com/LFPy/LFPy>`_
 
 
 Developing LFPy

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     include_package_data=True,
     cmdclass = cmdclass,
     ext_modules = ext_modules,
-    url='http://LFPy.github.io',
+    url='http://LFPy.readthedocs.io',
     download_url = 'https://github.com/LFPy/LFPy/tarball/v2.0',
     license='LICENSE',
     description='A module for modeling extracellular potentials of multicompartment neuron models built on NEURON',


### PR DESCRIPTION
removed some references to old documentation at lfpy.github.io which now redirects to lfpy.readthedocs.io