### PR TITLE
Got NaN in EEG calculation due to numerical round-off error, causing …

### DIFF
--- a/LFPy/eegmegcalc.py
+++ b/LFPy/eegmegcalc.py
@@ -650,6 +650,12 @@ class FourSphereVolumeConductor(object):
                              np.linalg.norm(x, axis=1).reshape(1, len(x)))
         denominator[np.where(denominator == 0)] = 1e-12
         cos_phi = np.dot(rxy, x.T) / denominator
+
+        # Numerical round-off error can cause cos_phi to be slightly above 1.0,
+        # resulting in a NaN.
+        cos_phi[np.where(cos_phi > 1.0)] -= 1e-6
+        cos_phi[np.where(cos_phi < -1.0)] += 1e-6
+
         cos_phi = np.nan_to_num(cos_phi)
         phi_temp = np.arccos(cos_phi) # nb: phi_temp is in range [0, pi]
         phi = phi_temp

--- a/LFPy/eegmegcalc.py
+++ b/LFPy/eegmegcalc.py
@@ -653,8 +653,8 @@ class FourSphereVolumeConductor(object):
 
         # Numerical round-off error can cause cos_phi to be slightly above 1.0,
         # resulting in a NaN.
-        cos_phi[np.where(cos_phi > 1.0)] -= 1e-6
-        cos_phi[np.where(cos_phi < -1.0)] += 1e-6
+        cos_phi[np.where(cos_phi > 1.0)] = 1.
+        cos_phi[np.where(cos_phi < -1.0)] = -1.
 
         cos_phi = np.nan_to_num(cos_phi)
         phi_temp = np.arccos(cos_phi) # nb: phi_temp is in range [0, pi]


### PR DESCRIPTION
…cos_phi to be slightly outside valid range of [-1,1]. Fixed by adding small number.