### PR TITLE
Synapse bug

### DIFF
--- a/LFPy/network.py
+++ b/LFPy/network.py
@@ -198,16 +198,16 @@ class NetworkCell(TemplateCell):
             cell.rng_list.append(rng) # must store ref to rng object
         cell.netconsynapses.append(syntype(x, sec=sec))
 
-        # check that synapses are parameterized correctly
-        if assert_syn_values:
-            for key, value in synparams.items():
-                exec("cell.netconsynapses[-1].{} = {}".format(key, value))
-                try:
-                    np.testing.assert_almost_equal(getattr(cell.netconsynapses[-1], key), value)
-                except AssertionError:
-                    raise AssertionError('{} = {} != {}'.format(key,
-                                                                getattr(cell.netconsynapses[-1], key),
-                                                                value))
+        for key, value in synparams.items():
+            exec("cell.netconsynapses[-1].{} = {}".format(key, value))
+            # check that synapses are parameterized correctly
+            if assert_syn_values:
+                    try:
+                        np.testing.assert_almost_equal(getattr(cell.netconsynapses[-1], key), value)
+                    except AssertionError:
+                        raise AssertionError('{} = {} != {}'.format(key,
+                                                                    getattr(cell.netconsynapses[-1], key),
+                                                                    value))
 
 
     def create_spike_detector(self, target=None, threshold=-10.,

--- a/LFPy/network.py
+++ b/LFPy/network.py
@@ -202,12 +202,12 @@ class NetworkCell(TemplateCell):
             exec("cell.netconsynapses[-1].{} = {}".format(key, value))
             # check that synapses are parameterized correctly
             if assert_syn_values:
-                    try:
-                        np.testing.assert_almost_equal(getattr(cell.netconsynapses[-1], key), value)
-                    except AssertionError:
-                        raise AssertionError('{} = {} != {}'.format(key,
-                                                                    getattr(cell.netconsynapses[-1], key),
-                                                                    value))
+                try:
+                    np.testing.assert_almost_equal(getattr(cell.netconsynapses[-1], key), value)
+                except AssertionError:
+                    raise AssertionError('{} = {} != {}'.format(key,
+                                                                getattr(cell.netconsynapses[-1], key),
+                                                                value))
 
 
     def create_spike_detector(self, target=None, threshold=-10.,


### PR DESCRIPTION
Fixed bug that made synapse parameters be ignored unless assert_syn_values = True.

Tests pas, and problem with only excitatory synapses is fixed locally.