### PR TITLE
remove setuptools runtime dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         ],
     install_requires = [
-        'setuptools>=23.1.0',
         'numpy>=1.8',
         'scipy>=0.14',
         'Cython>=0.20',


### PR DESCRIPTION
setuptools is not a runtime dependency, which is what `install_requires` specifies.
The setuptools version is already fixed by the time `install_requires` is parsed (by setuptools).
Build dependencies can be specified with `setup_requires` if so desired.