### PR TITLE
Added fix for small bug in Cell.get_closest_idx

### DIFF
--- a/LFPy/cell.py
+++ b/LFPy/cell.py
@@ -814,7 +814,7 @@ class Cell(object):
         dist = ((self.xmid[idx] - x)**2 +
                 (self.ymid[idx] - y)**2 +
                 (self.zmid[idx] - z)**2)
-        return np.argmin(dist)
+        return idx[np.argmin(dist)]
 
     def get_rand_idx_area_norm(self, section='allsec', nidx=1,
                                z_min=-1E6, z_max=1E6):

--- a/LFPy/test/test_cell.py
+++ b/LFPy/test/test_cell.py
@@ -556,6 +556,17 @@ class testCell(unittest.TestCase):
         self.assertEqual(cell.get_closest_idx(x=-25, y=0, z=175),
                              cell.get_idx(section='dend[1]')[0])
 
+    def test_cell_get_closest_idx_01(self):
+        cell = LFPy.Cell(morphology=os.path.join(LFPy.__path__[0], 'test',
+                                                  'ball_and_sticks.hoc' ))
+        x = -41.7
+        z = 156.7
+        sec_name = "dend"
+
+        idx1 = cell.get_closest_idx(x=x, z=z)
+        idx2 = cell.get_closest_idx(x=x, z=z, section=sec_name)
+        self.assertEqual(idx1, idx2)
+
 
     def test_cell_get_idx_children_00(self):
         cell = LFPy.Cell(morphology=os.path.join(LFPy.__path__[0], 'test',


### PR DESCRIPTION
The function Cell.get_closest_idx only worked perfectly when the 'section' was not specified. Otherwise it would give the wrong idx. Added fix and test.