### PR TITLE
fixed bug in decompose_dipole, eegmegcalc.py

### DIFF
--- a/LFPy/eegmegcalc.py
+++ b/LFPy/eegmegcalc.py
@@ -454,8 +454,6 @@ class FourSphereVolumeConductor(object):
         else:
             p_rad = np.zeros((n_timesteps, 3))
             p_tan = np.zeros((n_timesteps, 3))
-        print('p_rad:', p_rad)
-        print('p_tan:', p_tan)
         if np.linalg.norm(p_rad) != 0.:
             pot_rad = self._calc_rad_potential(p_rad)
         else:

--- a/LFPy/eegmegcalc.py
+++ b/LFPy/eegmegcalc.py
@@ -415,7 +415,7 @@ class FourSphereVolumeConductor(object):
                  'Can be avoided by placing dipole further away from brain surface.')
 
         if any(r < self._rz for r in self.r):
-            raise RuntimeError('Electrode must be farther away from'
+            raise RuntimeError('Electrode must be farther away from '
                                'brain center than dipole: r > rz.'
                                'r = %s, rz = %s', self.r, self._rz)
 
@@ -454,7 +454,8 @@ class FourSphereVolumeConductor(object):
         else:
             p_rad = np.zeros((n_timesteps, 3))
             p_tan = np.zeros((n_timesteps, 3))
-
+        print('p_rad:', p_rad)
+        print('p_tan:', p_tan)
         if np.linalg.norm(p_rad) != 0.:
             pot_rad = self._calc_rad_potential(p_rad)
         else:
@@ -542,9 +543,8 @@ class FourSphereVolumeConductor(object):
             Shape (n_timesteps, 3) array, tangential part of p,
             orthogonal to self._rz
         """
-        p_rad = p*self._z
+        p_rad = np.dot(p, self._z).reshape(len(p),1)*self._z.reshape(1, len(self._z))
         p_tan = p - p_rad
-
         return p_rad, p_tan
 
     def _calc_rad_potential(self, p_rad):

--- a/LFPy/test/test_eegmegcalc.py
+++ b/LFPy/test/test_eegmegcalc.py
@@ -206,11 +206,38 @@ class testFourSphereVolumeConductor(unittest.TestCase):
         with np.testing.assert_raises(ValueError):
             LFPy.FourSphereVolumeConductor(radii, sigmas, r_el2)
 
-    def test_decompose_dipole(self):
+    def test_decompose_dipole01(self):
         '''Test radial and tangential parts of dipole sums to dipole'''
         P1 = np.array([[1., 1., 1.]])
         p_rad, p_tan = decompose_dipole(P1)
         np.testing.assert_equal(p_rad + p_tan, P1)
+
+    def test_decompose_dipole02(self):
+        '''Test radial and tangential parts of dipole sums to dipole'''
+        radii = [88000, 90000, 95000, 100000]
+        sigmas = [0.3, 1.5, 0.015, 0.3]
+        ps = np.array([[ 1000., 0., 0.],
+                       [-1000., 0., 0.],
+                       [0.,  1000., 0.],
+                       [0., -1000., 0.],
+                       [0., 0.,  1000.],
+                       [0., 0., -1000.],
+                       [10., 20., 30.],
+                       [-10., -20., -30.]])
+        p_locs = np.array([[ 87000., 0., 0.],
+                           [-87000., 0., 0.],
+                           [0.,  87000., 0.],
+                           [0., -87000., 0.],
+                           [0., 0.,  87000.],
+                           [0., 0., -87000.],
+                           [80000., 2000., 3000.],
+                           [-2000., -80000., -3000.]])
+        el_locs = np.array([[90000., 5000., -5000.]])
+        fs = LFPy.FourSphereVolumeConductor(radii, sigmas, el_locs)
+        for p_loc in p_locs:
+            fs._rz_params(p_loc)
+            p_rads, p_tans = fs._decompose_dipole(ps)
+            np.testing.assert_equal(p_rads + p_tans, ps)
 
     def test_rad_dipole(self):
         '''Test that radial part of decomposed dipole is correct'''


### PR DESCRIPTION
When implementing #142, I accidentally left in a bug which would give potentials with opposite sign for dipole locations x<0/ y<0 /z<0. =/

Fixed bug and added test.