### PR TITLE
converted run_simulation._run_simulation to Cell class method

### DIFF
--- a/LFPy/run_simulation.py
+++ b/LFPy/run_simulation.py
@@ -51,25 +51,12 @@ def _run_simulation(cell, cvode, variable_dt=False, atol=0.001, rtol=0.):
 
     cell._loadspikes()
 
-    #print sim.time and realtime factor at intervals
-    counter = 0.
-    t0 = time()
-    ti = neuron.h.t
-    if cell.tstop >= 10000:
-        interval = 1000. / cell.dt
-    else:
-        interval = 100. / cell.dt
+    # advance simulation until tstop
+    neuron.run(cell.tstop)
 
-    while neuron.h.t < cell.tstop:
+    # for consistency with 'old' behaviour where tstop is included in tvec:
+    if neuron.h.t < cell.tstop:
         neuron.h.fadvance()
-        counter += 1.
-        if counter % interval == 0:
-            rtfactor = (neuron.h.t - ti) * 1E-3 / (time() - t0)
-            if cell.verbose:
-                print('t = {:.0f}, realtime factor: {:.3f}'.format(neuron.h.t,
-                                                                   rtfactor))
-            t0 = time()
-            ti = neuron.h.t
 
 
 def _run_simulation_with_electrode(cell, cvode, electrode=None,

--- a/LFPy/run_simulation.py
+++ b/LFPy/run_simulation.py
@@ -21,44 +21,6 @@ import neuron
 from pathlib import Path
 
 
-def _run_simulation(cell, cvode, variable_dt=False, atol=0.001, rtol=0.):
-    '''
-    Running the actual simulation in NEURON, simulations in NEURON
-    are now interruptable.
-    '''
-    neuron.h.dt = cell.dt
-
-    # variable dt method
-    if variable_dt:
-        cvode.active(1)
-        cvode.atol(atol)
-        cvode.rtol(rtol)
-    else:
-        cvode.active(0)
-
-    # re-initialize state
-    neuron.h.finitialize(cell.v_init)
-
-    # initialize current- and record
-    if cvode.active():
-        cvode.re_init()
-    else:
-        neuron.h.fcurrent()
-    neuron.h.frecord_init()
-
-    # Starting simulation at tstart
-    neuron.h.t = cell.tstart
-
-    cell._loadspikes()
-
-    # advance simulation until tstop
-    neuron.run(cell.tstop)
-
-    # for consistency with 'old' behaviour where tstop is included in tvec:
-    if neuron.h.t < cell.tstop:
-        neuron.h.fadvance()
-
-
 def _run_simulation_with_electrode(cell, cvode, electrode=None,
                                    variable_dt=False, atol=0.001, rtol=0.,
                                    to_memory=True, to_file=False,

--- a/LFPy/run_simulation.pyx
+++ b/LFPy/run_simulation.pyx
@@ -42,43 +42,27 @@ def _run_simulation(cell, cvode, variable_dt=False, atol=0.001, rtol=0.):
     else:
         cvode.active(0)
 
-    #re-initialize state
+    # re-initialize state
     neuron.h.finitialize(cell.v_init)
 
-    #initialize current- and record
+    # initialize current- and record
     if cvode.active():
         cvode.re_init()
     else:
         neuron.h.fcurrent()
     neuron.h.frecord_init()
 
-    #Starting simulation at t != 0
+    # Starting simulation at t != 0
     neuron.h.t = cell.tstart
 
     cell._loadspikes()
 
-    #print sim.time at intervals
-    cdef int counter = 0
-    cdef double interval
-    cdef double tstop = cell.tstop
-    cdef double t0 = time()
-    cdef double ti = neuron.h.t
-    cdef double rtfactor
-    if tstop >= 10000:
-        interval = 1000. / cell.dt
-    else:
-        interval = 100. / cell.dt
+    # advance simulation until tstop
+    neuron.run(cell.tstop)
 
-    while neuron.h.t < tstop:
+    # for consistency with 'old' behaviour where tstop is included in tvec:
+    if neuron.h.t < cell.tstop:
         neuron.h.fadvance()
-        counter += 1
-        if counter % interval == 0:
-            rtfactor = (neuron.h.t - ti)  * 1E-3 / (time() - t0 + 1E-9)
-            if cell.verbose:
-                print('t = {:.0f}, realtime factor: {:.3f}'.format(neuron.h.t,
-                                                                   rtfactor))
-            t0 = time()
-            ti = neuron.h.t
 
 
 def _run_simulation_with_electrode(cell, cvode, electrode=None,

--- a/LFPy/run_simulation.pyx
+++ b/LFPy/run_simulation.pyx
@@ -27,44 +27,6 @@ ctypedef np.float64_t DTYPE_t
 ctypedef Py_ssize_t   LTYPE_t
 
 
-def _run_simulation(cell, cvode, variable_dt=False, atol=0.001, rtol=0.):
-    """
-    Running the actual simulation in NEURON, simulations in NEURON
-    is now interruptable.
-    """
-    neuron.h.dt = cell.dt
-
-    # variable dt method
-    if variable_dt:
-        cvode.active(1)
-        cvode.atol(atol)
-        cvode.rtol(rtol)
-    else:
-        cvode.active(0)
-
-    # re-initialize state
-    neuron.h.finitialize(cell.v_init)
-
-    # initialize current- and record
-    if cvode.active():
-        cvode.re_init()
-    else:
-        neuron.h.fcurrent()
-    neuron.h.frecord_init()
-
-    # Starting simulation at t != 0
-    neuron.h.t = cell.tstart
-
-    cell._loadspikes()
-
-    # advance simulation until tstop
-    neuron.run(cell.tstop)
-
-    # for consistency with 'old' behaviour where tstop is included in tvec:
-    if neuron.h.t < cell.tstop:
-        neuron.h.fadvance()
-
-
 def _run_simulation_with_electrode(cell, cvode, electrode=None,
                                    variable_dt=False, atol=0.001, rtol=0.,
                                    to_memory=True, to_file=False,

--- a/LFPy/templatecell.py
+++ b/LFPy/templatecell.py
@@ -21,7 +21,7 @@ import pickle
 import numpy as np
 import neuron
 from LFPy import Cell, RecExtElectrode
-from LFPy.run_simulation import _run_simulation, _run_simulation_with_electrode
+from LFPy.run_simulation import _run_simulation_with_electrode
 
 class TemplateCell(Cell):
 
@@ -150,7 +150,7 @@ class TemplateCell(Cell):
         Cell.__init__(self, **kwargs)
 
     def _load_geometry(self):
-        """Load the morphology-file in NEURON""" 
+        """Load the morphology-file in NEURON"""
         #the python cell object we are loading the morphology into:
         self.template = getattr(neuron.h, self.templatename)(self.templateargs)
 

--- a/LFPy/templatecell.py
+++ b/LFPy/templatecell.py
@@ -17,11 +17,9 @@ GNU General Public License for more details.
 import os
 import posixpath
 import sys
-import pickle
-import numpy as np
 import neuron
-from LFPy import Cell, RecExtElectrode
-from LFPy.run_simulation import _run_simulation_with_electrode
+from LFPy import Cell
+
 
 class TemplateCell(Cell):
 


### PR DESCRIPTION
Closes #216 

Should be faster than the existing implementation without resorting to Cython:
```
%timeit cell.simulate()
----------------------
neuron.h.fadvance() while loop, python: 6.43 s ± 65.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
neuron.run(), python: 5.05 s ± 206 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
neuron.h.fadvance() while loop, cython: 6.33 s ± 65.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
neuron.run, cython: 4.79 s ± 33.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
LFPy.Cell._run_simulation: 4.76 s ± 18.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
Set up:
```
cell = LFPy.Cell(morphology='examples/morphologies/L5_Mainen96_LFPy.hoc', 
                 passive=True,
                 tstop=10000, 
                 dt=0.05)
syn = LFPy.Synapse(cell=cell, idx=0, syntype='ExpSyn', e=0, weight=0.01, tau=5)
syn.set_spike_times_w_netstim(interval=5, number=10000)
```