### PR TITLE
Replaced static default parameters with more suited pattern. closes #253

### DIFF
--- a/LFPy/cell.py
+++ b/LFPy/cell.py
@@ -126,9 +126,7 @@ class Cell(object):
                  Ra=None,
                  cm=None,
                  passive=False,
-                 passive_parameters=dict(
-                     g_pas=0.001,
-                     e_pas=-70.),
+                 passive_parameters=None,
                  extracellular=False,
                  tstart=0.,
                  tstop=100.,
@@ -147,6 +145,9 @@ class Cell(object):
                  **kwargs):
         self.verbose = verbose
         self.pt3d = pt3d
+
+        if passive_parameters is None:
+            passive_parameters = dict(g_pas=0.001, e_pas=-70.)
 
         # check if there are un-used keyword arguments present in kwargs
         for key, value in kwargs.items():

--- a/LFPy/eegmegcalc.py
+++ b/LFPy/eegmegcalc.py
@@ -86,12 +86,16 @@ class FourSphereVolumeConductor(lfpykit.eegmegcalc.FourSphereVolumeConductor):
     """
     def __init__(self,
                  r_electrodes,
-                 radii=[79000., 80000., 85000., 90000.],
-                 sigmas=[0.3, 1.5, 0.015, 0.3],
+                 radii=None,
+                 sigmas=None,
                  iter_factor=2. / 99. * 1e-6):
         """
         Initialize class FourSphereVolumeConductor
         """
+        if radii is None:
+            radii = [79000., 80000., 85000., 90000.]
+        if sigmas is None:
+            sigmas = [0.3, 1.5, 0.015, 0.3]
         super().__init__(r_electrodes=r_electrodes,
                          radii=radii,
                          sigmas=sigmas,

--- a/LFPy/network.py
+++ b/LFPy/network.py
@@ -246,12 +246,12 @@ class NetworkCell(TemplateCell):
 
 class DummyCell(object):
     def __init__(self, totnsegs=0,
-                 x=np.array([]),
-                 y=np.array([]),
-                 z=np.array([]),
-                 d=np.array([]),
-                 area=np.array([]),
-                 somainds=np.array([])):
+                 x=None,
+                 y=None,
+                 z=None,
+                 d=None,
+                 area=None,
+                 somainds=None:
         """
         Dummy Cell object initialized with all attributes needed for LFP
         calculations using the LFPy.RecExtElectrode class and methods.
@@ -272,12 +272,12 @@ class DummyCell(object):
         """
         # set attributes
         self.totnsegs = totnsegs
-        self.x = x
-        self.y = y
-        self.z = z
-        self.d = d
-        self.area = area
-        self.somainds = somainds
+        self.x = x if x is not None else np.array([])
+        self.y = y if y is not None else np.array([])
+        self.z = z if z is not None else np.array([])
+        self.d = d if d is not None else np.array([])
+        self.area = area if area is not None else np.array([])
+        self.somainds = somainds if somainds is not None else np.array([])
 
     def get_idx(self, section="soma"):
         if section == "soma":
@@ -322,8 +322,8 @@ class NetworkPopulation(object):
     """
     def __init__(self, CWD=None, CELLPATH=None, first_gid=0, Cell=NetworkCell,
                  POP_SIZE=4, name='L5PC',
-                 cell_args=dict(), pop_args=dict(),
-                 rotation_args=dict(),
+                 cell_args=None, pop_args=None,
+                 rotation_args=None,
                  OUTPUTPATH='example_parallel_network'):
         # set class attributes
         self.CWD = CWD
@@ -332,9 +332,9 @@ class NetworkPopulation(object):
         self.Cell = Cell
         self.POP_SIZE = POP_SIZE
         self.name = name
-        self.cell_args = cell_args
-        self.pop_args = pop_args
-        self.rotation_args = rotation_args
+        self.cell_args = cell_args if cell_args is not None else dict()
+        self.pop_args = pop_args if pop_args is not None else dict()
+        self.rotation_args = rotation_args if rotation_args is not None else dict()
         self.OUTPUTPATH = OUTPUTPATH
 
         # create folder for output if it does not exist
@@ -543,8 +543,8 @@ class Network(object):
 
     def create_population(self, CWD=None, CELLPATH=None, Cell=NetworkCell,
                           POP_SIZE=4, name='L5PC',
-                          cell_args=dict(), pop_args=dict(),
-                          rotation_args=dict()):
+                          cell_args=None, pop_args=None,
+                          rotation_args=None):
         """
         Create and append a distributed POP_SIZE-sized population of cells of
         type Cell with the corresponding name. Cell-object references, gids on

--- a/LFPy/network.py
+++ b/LFPy/network.py
@@ -251,7 +251,7 @@ class DummyCell(object):
                  z=None,
                  d=None,
                  area=None,
-                 somainds=None:
+                 somainds=None):
         """
         Dummy Cell object initialized with all attributes needed for LFP
         calculations using the LFPy.RecExtElectrode class and methods.

--- a/LFPy/network.py
+++ b/LFPy/network.py
@@ -334,7 +334,8 @@ class NetworkPopulation(object):
         self.name = name
         self.cell_args = cell_args if cell_args is not None else dict()
         self.pop_args = pop_args if pop_args is not None else dict()
-        self.rotation_args = rotation_args if rotation_args is not None else dict()
+        self.rotation_args = rotation_args if rotation_args is not None \
+            else dict()
         self.OUTPUTPATH = OUTPUTPATH
 
         # create folder for output if it does not exist


### PR DESCRIPTION
I've left in a lot of occurences of the pattern described in #253, I personally think they should all be replaced since even the most innocent uses of this pattern can lead to problems:

#### Dev 1 writes a function

```python
def jolly_func(defaults=dict(a=5,b=10)):
  # Lots of other code here
  # ...
  other_func(**defaults)
```

#### Dev 2 extends the function

```python
def jolly_func(do_special=False, defaults=dict(a=5, b=10)):
  if do_special:
    defaults["special"] = 15
  # Lots of other code here
  # ...
  other_func(**defaults)
```

And if the function is ever called with `do_special=True` any subsequent call will already have `defaults["special"] = 15` set.

But in this PR I've surpressed my puritanism and tried to discern which occurences could actually cause problems between instances of the same class or repeated calls to the same function in its current form.

Closes #253 