### PR TITLE
Replaced exec calls by setattr

### DIFF
--- a/LFPy/cell.py
+++ b/LFPy/cell.py
@@ -655,7 +655,7 @@ class Cell(object):
                     stim = eval(command, locals(), globals())
                     for param in list(kwargs.keys()):
                         try:
-                            exec('stim.{} = {}'.format(param, kwargs[param]))
+                            setattr(stim, param, kwargs[param])
                         except SyntaxError:
                             ERRMSG = ''.join([
                                 '',

--- a/LFPy/cell.py
+++ b/LFPy/cell.py
@@ -655,7 +655,7 @@ class Cell(object):
                     stim = eval(command, locals(), globals())
                     for key, value in kwargs.items():
                         try:
-                          itr = enumerate(iter(value))
+                            itr = enumerate(iter(value))
                         except TypeError:
                             setattr(stim, key, value)
                         else:

--- a/LFPy/cell.py
+++ b/LFPy/cell.py
@@ -653,17 +653,14 @@ class Cell(object):
                 if i == idx:
                     command = cmd1 + pptype + cmd2
                     stim = eval(command, locals(), globals())
-                    for param in list(kwargs.keys()):
+                    for key, value in kwargs.items():
                         try:
-                            setattr(stim, param, kwargs[param])
-                        except SyntaxError:
-                            ERRMSG = ''.join([
-                                '',
-                                'Point process type "{0}" might not '.format(
-                                    pptype),
-                                'recognize attribute "{0}". '.format(param),
-                                'Check for misspellings'])
-                            raise Exception(ERRMSG)
+                          itr = enumerate(iter(value))
+                        except TypeError:
+                            setattr(stim, key, value)
+                        else:
+                            for i, v in itr:
+                                getattr(stim, key)[i] = v
                     self.stimlist.append(stim)
 
                     # record current
@@ -712,8 +709,8 @@ class Cell(object):
             self.somapos[2] = self.z[self.somaidx].mean()
         elif self.somaidx.size == 0:
             if self.verbose:
-                print('There is no soma!')
-                print('using first segment as root point')
+                warn("There is no soma!" +
+                     "Using first segment as root point")
             self.somaidx = np.array([0])
             self.somapos = np.zeros(3)
             self.somapos[0] = self.x[self.somaidx].mean()

--- a/LFPy/network.py
+++ b/LFPy/network.py
@@ -203,7 +203,7 @@ class NetworkCell(TemplateCell):
         cell.netconsynapses.append(syntype(x, sec=sec))
 
         for key, value in synparams.items():
-            exec("cell.netconsynapses[-1].{} = {}".format(key, value))
+            setattr(cell.netconsynapses[-1], key, value)
             # check that synapses are parameterized correctly
             if assert_syn_values:
                 try:

--- a/LFPy/pointprocess.py
+++ b/LFPy/pointprocess.py
@@ -279,12 +279,8 @@ class StimIntElectrode(PointProcess):
     >>>         'idx': 0,
     >>>         'record_current': True,
     >>>         'pptype': 'VClamp',
-    >>>         'amp[0]': -70,
-    >>>         'dur[0]': 10,
-    >>>         'amp[1]': 0,
-    >>>         'dur[1]': 20,
-    >>>         'amp[2]': -70,
-    >>>         'dur[2]': 10,
+    >>>         'amp': [-70, 0, -70],
+    >>>         'dur': [10, 20, 10],
     >>>    },
     >>>    {
     >>>        'idx': 0,
@@ -297,23 +293,22 @@ class StimIntElectrode(PointProcess):
     >>>        'dur3': 10,
     >>>        'amp3': -70,
     >>>     },
-    >>>  ]
-    >>>  # create a cell instance for each electrode
-    >>>  for pointprocess in pointprocesses:
-    >>>      cell = LFPy.Cell(morphology=os.path.join('examples',
-    >>>                                               'morphologies',
-    >>>                                               'L5_Mainen96_LFPy.hoc'),
-    >>>                       passive=True)
-    >>>      stimulus = LFPy.StimIntElectrode(cell, **pointprocess)
-    >>>      cell.simulate()
-    >>>      pl.subplot(211)
-    >>>      pl.plot(cell.tvec, stimulus.i, label=pointprocess['pptype'])
-    >>>      pl.legend(loc='best')
-    >>>      pl.title('Stimulus currents (nA)')
-    >>>      pl.subplot(212)
-    >>>      pl.plot(cell.tvec, cell.somav, label=pointprocess['pptype'])
-    >>>      pl.legend(loc='best')
-    >>>      pl.title('Somatic potential (mV)')
+    >>> ]
+    >>> # create a cell instance for each electrode
+    >>> fix, axes = pl.subplots(2, 1, sharex=True)
+    >>> for pointprocess in pointprocesses:
+    >>>     cell = LFPy.Cell(morphology=os.path.join('examples',
+    >>>                                              'morphologies',
+    >>>                                              'L5_Mainen96_LFPy.hoc'),
+    >>>                      passive=True)
+    >>>     stimulus = LFPy.StimIntElectrode(cell, **pointprocess)
+    >>>     cell.simulate()
+    >>>     axes[0].plot(cell.tvec, stimulus.i, label=pointprocess['pptype'])
+    >>>     axes[0].legend(loc='best')
+    >>>     axes[0].set_title('Stimulus currents (nA)')
+    >>>     axes[1].plot(cell.tvec, cell.somav, label=pointprocess['pptype'])
+    >>>     axes[1].legend(loc='best')
+    >>>     axes[1].set_title('Somatic potential (mV)')
 
     See also
     --------

--- a/LFPy/test/test_network.py
+++ b/LFPy/test/test_network.py
@@ -285,12 +285,8 @@ class testNetwork(unittest.TestCase):
         clampParams = {
             'idx': 0,
             'pptype': 'VClamp',
-            'amp[0]': -65,
-            'dur[0]': 10,
-            'amp[1]': 0,
-            'dur[1]': 1,
-            'amp[2]': -65,
-            'dur[2]': 1E8,
+            'amp': [-65, 0, -65],
+            'dur': [10, 1, 1E8],
         }
 
         # set up

--- a/LFPy/test/test_pointprocess.py
+++ b/LFPy/test/test_pointprocess.py
@@ -296,12 +296,8 @@ class testStimIntElectrode(unittest.TestCase):
                                      record_potential=True,
                                      **{'idx': 0,
                                         'pptype': 'VClamp',
-                                        'amp[0]': -65,
-                                        'dur[0]': 10,
-                                        'amp[1]': -55.,
-                                        'dur[1]': 20,
-                                        'amp[2]': -65,
-                                        'dur[2]': 10,
+                                        'amp': [-65, -55, -65],
+                                        'dur': [10, 20, 10],
                                         })
         cell.simulate()
         gt = np.zeros(cell.tvec.size) - 65.


### PR DESCRIPTION
Closes #252. I left in the `eval` statements because attribute access of PointProcesses on  `h` before NEURON 7.8 is broken and you want to support NEURON 7.6+.

I don't think `SyntaxError` will ever be thrown now, you might want to take another look at the edge cases now. Also take a look at https://github.com/neuronsimulator/nrn/issues/731, so this PR might not really be all that NEURON friendly since the original `exec` probably caught all of those with a `SyntaxError` :)