### PR TITLE
extended Network.connect() save_connections feature to include all synaptic info

### DIFF
--- a/LFPy/network.py
+++ b/LFPy/network.py
@@ -882,7 +882,8 @@ class Network(object):
                     synDataArray[i]['z'] = z
                 # Dump to hdf5 file, append to file if entry exists
                 with h5py.File(os.path.join(self.OUTPUTPATH,
-                                            'synapse_connections.h5'), 'a') as f:
+                                            'synapse_connections.h5'),
+                               'a') as f:
                     key = '{}:{}'.format(pre, post)
                     if key in f.keys():
                         del f[key]

--- a/LFPy/network.py
+++ b/LFPy/network.py
@@ -737,14 +737,20 @@ class Network(object):
             if True (default False), save instantiated connections to HDF5 file
             "Network.OUTPUTPATH/synapse_positions.h5" as dataset "<pre>:<post>"
             using a structured ndarray with dtype
-            [('gid', 'i8'), ('x', float), ('y', float), ('z', float)]
-            where gid is postsynaptic cell id, and x,y,z the corresponding
+            [('gid_pre'), ('gid', 'i8'), ('weight', 'f8'), ('delay', 'f8'),
+             ('sec', 'U64'), ('sec.x', 'f8'),
+             ('x', 'f8'), ('y', 'f8'), ('z', 'f8')],
+            where `gid_pre` is presynapic cell id,
+            `gid` is postsynaptic cell id,
+            `weight` connection weight, `delay` connection delay,
+            `sec` section name, `sec.x` relative location on section,
+            and `x`,`y`,`z` the corresponding
             midpoint coordinates of the target compartment.
         """
         # set up connections from all cells in presynaptic to post across RANKs
         n0 = self.populations[pre].first_gid
         # gids of presynaptic neurons:
-        pre_gids = np.arange(n0, n0 + self.populations[pre].POP_SIZE)
+        gids_pre = np.arange(n0, n0 + self.populations[pre].POP_SIZE)
 
         # count connections and synapses made on this RANK
         conncount = connectivity.astype(int).sum()
@@ -755,17 +761,17 @@ class Network(object):
         syn_idx_pos = []
 
         # iterate over gids on this RANK and create connections
-        for i, (post_gid, cell) in enumerate(zip(self.populations[post].gids,
+        for i, (gid_post, cell) in enumerate(zip(self.populations[post].gids,
                                                  self.populations[post].cells)
                                              ):
             # do NOT iterate over all possible presynaptic neurons
-            for pre_gid in pre_gids[connectivity[:, i]]:
+            for gid_pre in gids_pre[connectivity[:, i]]:
                 # throw a warning if sender neuron is identical to receiving
                 # neuron
-                if post_gid == pre_gid:
+                if gid_post == gid_pre:
                     print(
                         'connecting cell w. gid {} to itself (RANK {})'.format(
-                            post_gid, RANK))
+                            gid_post, RANK))
 
                 # assess number of synapses
                 if multapsefun is None:
@@ -799,21 +805,22 @@ class Network(object):
                     j = delays < mindelay
                     delays[j] = delayfun(size=j.sum(), **delayargs)
 
-                for i, ((idx, secname, x), weight, delay) in enumerate(
+                for i, ((idx, secname, secx), weight, delay) in enumerate(
                         zip(secs, weights, delays)):
                     cell.create_synapse(
                         cell,
                         # TODO: Find neater way of accessing
-                        # Section reference, this seems slow
+                        # Section reference, this looks slow
                         sec=list(
                             cell.allseclist)[
                             np.where(
                                 np.array(
                                     cell.allsecnames) == secname)[0][0]],
-                        x=x, syntype=syntype,
+                        x=secx,
+                        syntype=syntype,
                         synparams=synparams)
                     # connect up NetCon object
-                    nc = self.pc.gid_connect(pre_gid, cell.netconsynapses[-1])
+                    nc = self.pc.gid_connect(gid_pre, cell.netconsynapses[-1])
                     nc.weight[0] = weight
                     nc.delay = delays[i]
                     self.netconlist.append(nc)
@@ -823,7 +830,13 @@ class Network(object):
                     cell.synidx.append(idx)
 
                     # store gid and xyz-coordinate of synapse positions
-                    syn_idx_pos.append((cell.gid, cell.x[idx].mean(axis=-1),
+                    syn_idx_pos.append((gid_pre,
+                                        cell.gid,
+                                        weight,
+                                        delays[i],
+                                        secname,
+                                        secx,
+                                        cell.x[idx].mean(axis=-1),
                                         cell.y[idx].mean(axis=-1),
                                         cell.z[idx].mean(axis=-1)))
 
@@ -846,11 +859,24 @@ class Network(object):
                 synData = flattenlist(COMM.gather(syn_idx_pos))
 
                 # convert to structured array
-                dtype = [('gid', 'i8'), ('x', float),
-                         ('y', float), ('z', float)]
+                dtype = [('gid_pre', 'i8'),
+                         ('gid', 'i8'),
+                         ('weight', 'f8'),
+                         ('delay', 'f8'),
+                         ('sec', 'S64'),
+                         ('sec.x', 'f8'),
+                         ('x', 'f8'),
+                         ('y', 'f8'),
+                         ('z', 'f8')]
                 synDataArray = np.empty((len(synData), ), dtype=dtype)
-                for i, (gid, x, y, z) in enumerate(synData):
+                for i, (gid_pre, gid, weight, delay, secname, secx, x, y, z
+                        ) in enumerate(synData):
+                    synDataArray[i]['gid_pre'] = gid_pre
                     synDataArray[i]['gid'] = gid
+                    synDataArray[i]['weight'] = weight
+                    synDataArray[i]['delay'] = delay
+                    synDataArray[i]['sec'] = secname
+                    synDataArray[i]['sec.x'] = secx
                     synDataArray[i]['x'] = x
                     synDataArray[i]['y'] = y
                     synDataArray[i]['z'] = z

--- a/LFPy/test/test_network.py
+++ b/LFPy/test/test_network.py
@@ -22,6 +22,7 @@ import LFPy
 import neuron
 import h5py
 import scipy.signal as ss
+import scipy.stats as st
 
 
 class testNetworkPopulation(unittest.TestCase):
@@ -588,6 +589,138 @@ class testNetwork(unittest.TestCase):
             np.testing.assert_equal(value[()], LFP)
         f.close()
 
+        network.pc.gid_clear()
+        os.system('rm -r tmp_testNetworkPopulation')
+        for population in network.populations.values():
+            for cell in population.cells:
+                cell.__del__()
+        neuron.h('forall delete_section()')
+
+
+    def test_Network_06(self):
+        cellParameters = dict(
+            morphology=os.path.join(
+                LFPy.__path__[0],
+                'test',
+                'ball_and_sticks_w_lists.hoc'),
+            templatefile=os.path.join(
+                LFPy.__path__[0],
+                'test',
+                'ball_and_stick_template.hoc'),
+            templatename='ball_and_stick_template',
+            templateargs=None,
+            passive=False,
+            dt=2**-3,
+            tstop=100,
+            delete_sections=False,
+        )
+
+        populationParameters = dict(
+            CWD=None,
+            CELLPATH=None,
+            Cell=LFPy.NetworkCell,
+            cell_args=cellParameters,
+            pop_args=dict(
+                radius=100,
+                loc=0.,
+                scale=20.),
+            rotation_args=dict(x=0, y=0),
+            POP_SIZE=4,
+            name='test',
+        )
+
+        networkParameters = dict(
+            dt=2**-3,
+            tstart=0.,
+            tstop=100.,
+            v_init=-65.,
+            celsius=6.3,
+            OUTPUTPATH='tmp_testNetworkPopulation'
+        )
+
+        def return_constant(size, value):
+            return np.ones(size) * value
+
+        connectionParameters = dict(
+            syntype=neuron.h.ExpSyn,
+            synparams={'tau': 2.0, 'e': 0.0},
+            weightfun=return_constant,
+            weightargs={'value': 0.1},
+            minweight=0,
+            delayfun=return_constant,
+            delayargs={'value': 2.},
+            mindelay=0.3,
+            multapsefun=None,  # 1 synapse per connection
+            save_connections=True,
+            syn_pos_args=dict(section=['soma'],
+                              fun=[st.norm] * 2,
+                              funargs=[dict(loc=0, scale=100)] * 2,
+                              funweights=[0.5] * 2,
+                              z_min=-1E6, z_max=1E6,
+                              )
+        )
+        # set up
+        network = LFPy.Network(**networkParameters)
+        network.create_population(**populationParameters)
+        connectivity = network.get_connectivity_rand(
+            pre='test', post='test', connprob=1)
+
+        # test set up
+        for population in network.populations.values():
+            self.assertTrue(len(population.cells) == population.POP_SIZE)
+            for cell, soma_pos, gid in zip(
+                    population.cells, population.soma_pos, population.gids):
+                self.assertTrue(isinstance(cell, LFPy.NetworkCell))
+                self.assertTrue((cell.somapos[0] == soma_pos['x']) &
+                                (cell.somapos[1] == soma_pos['y']) &
+                                (cell.somapos[2] == soma_pos['z']))
+                self.assertEqual(cell.gid, gid)
+                self.assertTrue(
+                    np.sqrt(
+                        soma_pos['x']**2 +
+                        soma_pos['y']**2) <= 100.)
+            np.testing.assert_equal(population.gids, np.arange(4))
+
+        np.testing.assert_equal(
+            connectivity.shape,
+            (population.POP_SIZE,
+             population.POP_SIZE))
+        np.testing.assert_equal(
+            connectivity.diagonal(), np.zeros(
+                population.POP_SIZE))
+
+        # connect and run sim
+        network.connect(pre='test', post='test', connectivity=connectivity,
+                        **connectionParameters)
+
+        # check that saved connections are indeed correct
+        f = h5py.File(os.path.join(network.OUTPUTPATH,
+                                   'synapse_connections.h5'), 'r')
+        conn_data = f['test:test'][()]
+
+        assert np.all(conn_data['weight'] ==
+                      connectionParameters['weightargs']['value'])
+        assert np.all(conn_data['delay'] ==
+                      connectionParameters['delayargs']['value'])
+        assert np.all(conn_data['sec.x'] == 0.5)
+        for cell in population.cells:
+            inds = conn_data['gid'] == cell.gid
+            assert np.all(conn_data['gid_pre'][inds] != cell.gid)
+            for secname in conn_data['sec'][inds]:
+                assert secname.decode() == \
+                    'ball_and_stick_template[{}].soma[0]'.format(cell.gid)
+            assert np.all(conn_data['x'][inds] == cell.x.mean(axis=-1)[0])
+            assert np.all(conn_data['y'][inds] == cell.y.mean(axis=-1)[0])
+            assert np.all(conn_data['z'][inds] == cell.z.mean(axis=-1)[0])
+
+        # check static connection parameters
+        synparams = f['synparams']['test:test']
+        assert synparams['mechanism'][()].decode() == \
+            connectionParameters['syntype'].__str__().strip('()')
+        for key, value in connectionParameters['synparams'].items():
+            assert synparams[key][()] == value
+
+        # clean exit
         network.pc.gid_clear()
         os.system('rm -r tmp_testNetworkPopulation')
         for population in network.populations.values():

--- a/LFPy/test/test_network.py
+++ b/LFPy/test/test_network.py
@@ -596,7 +596,6 @@ class testNetwork(unittest.TestCase):
                 cell.__del__()
         neuron.h('forall delete_section()')
 
-
     def test_Network_06(self):
         cellParameters = dict(
             morphology=os.path.join(

--- a/LFPy/version.py
+++ b/LFPy/version.py
@@ -1,1 +1,1 @@
-version = "2.2rc5"
+version = "2.2rc4"

--- a/examples/bioRxiv281717/figure_4.py
+++ b/examples/bioRxiv281717/figure_4.py
@@ -417,7 +417,7 @@ if __name__ == '__main__':
     bins = np.arange(0, -PSET.layer_data['thickness'].sum(), -50)[::-1]
 
     # file output
-    f = h5py.File(os.path.join(PSET.OUTPUTPATH, 'synapse_positions.h5'), 'r')
+    f = h5py.File(os.path.join(PSET.OUTPUTPATH, 'synapse_connections.h5'), 'r')
     for i, (m_post, post) in enumerate(zip(PSET.populationParameters['m_type'],
                                            PSET.populationParameters['me_type']
                                            )):

--- a/examples/example_network/example_network.py
+++ b/examples/example_network/example_network.py
@@ -238,10 +238,14 @@ if __name__ == '__main__':
     ##########################################################################
     # Main simulation
     ##########################################################################
-    # create directory for output:
-    if not os.path.isdir(OUTPUTPATH):
-        if RANK == 0:
+    if RANK == 0:
+        # create directory for output:
+        if not os.path.isdir(OUTPUTPATH):
             os.mkdir(OUTPUTPATH)
+        # remove old simulation output if directory exist
+        else:
+            for fname in os.listdir(OUTPUTPATH):
+                os.unlink(os.path.join(OUTPUTPATH, fname))
     COMM.Barrier()
 
     # instantiate Network:
@@ -289,6 +293,7 @@ if __name__ == '__main__':
                 multapsefun=multapseFunction,
                 multapseargs=multapseArguments[i][j],
                 syn_pos_args=synapsePositionArguments[i][j],
+                save_connections=False,
             )
 
     # set up extracellular recording device.
@@ -478,6 +483,7 @@ if __name__ == '__main__':
     synapseModel = None
     for population in network.populations.values():
         for cell in population.cells:
+            cell.__del__()
             cell = None
         population.cells = None
         population = None


### PR DESCRIPTION
Closes #292

LFPy.Network.connect(save_connections=True, **kwargs) saves instantiated connections to HDF5 file
`"Network.OUTPUTPATH/synapse_connections.h5"` as dataset `"<pre>:<post>"` using a structured ndarray with dtype
`[('gid_pre'), ('gid', 'i8'), ('weight', 'f8'), ('delay', 'f8'), ('sec', 'U64'), ('sec.x', 'f8'), ('x', 'f8'), ('y', 'f8'), ('z', 'f8')]`, where 
`gid_pre` is presynapic cell id, 
`gid` is postsynaptic cell id,
`weight` connection weight, 
`delay` connection delay,
`sec` section name, 
`sec.x` relative location on section,
and `x`,`y`,`z` the corresponding midpoint coordinates of the target compartment.