### PR TITLE
Turn hoc list attributes into protected

### DIFF
--- a/LFPy/cell.py
+++ b/LFPy/cell.py
@@ -561,8 +561,8 @@ class Cell(object):
             self._synvtorecord = []
         if not hasattr(self, '_hoc_netstimlist'):
             self._hoc_netstimlist = neuron.h.List()
-        if not hasattr(self, 'netconlist'):
-            self.netconlist = neuron.h.List()
+        if not hasattr(self, '_hoc_netconlist'):
+            self._hoc_netconlist = neuron.h.List()
         if not hasattr(self, 'sptimeslist'):
             self.sptimeslist = []
 
@@ -590,7 +590,7 @@ class Cell(object):
 
                     nc = neuron.h.NetCon(self._hoc_netstimlist[-1], syn)
                     nc.weight[0] = weight
-                    self.netconlist.append(nc)
+                    self._hoc_netconlist.append(nc)
 
                     # record current
                     if record_current:
@@ -1274,7 +1274,7 @@ class Cell(object):
             if len(self.synlist) == len(self.sptimeslist):
                 for i in range(int(self.synlist.count())):
                     for spt in self.sptimeslist[i]:
-                        self.netconlist.o(i).event(spt)
+                        self._hoc_netconlist.o(i).event(spt)
 
     def _set_soma_volt_recorder(self, dt):
         """Record somatic membrane potential"""

--- a/LFPy/cell.py
+++ b/LFPy/cell.py
@@ -629,8 +629,8 @@ class Cell(object):
             index of point process on cell
         """
 
-        if not hasattr(self, 'stimlist'):
-            self.stimlist = neuron.h.List()
+        if not hasattr(self, '_hoc_stimlist'):
+            self._hoc_stimlist = neuron.h.List()
         if not hasattr(self, '_stimitorecord'):
             self._stimitorecord = []
         if not hasattr(self, '_stimvtorecord'):
@@ -653,15 +653,17 @@ class Cell(object):
                         else:
                             for i, v in itr:
                                 getattr(stim, key)[i] = v
-                    self.stimlist.append(stim)
+                    self._hoc_stimlist.append(stim)
 
                     # record current
                     if record_current:
-                        self._stimitorecord.append(self.stimlist.count() - 1)
+                        self._stimitorecord.append(
+                            self._hoc_stimlist.count() - 1)
 
                     # record potential
                     if record_potential:
-                        self._stimvtorecord.append(self.stimlist.count() - 1)
+                        self._stimvtorecord.append(
+                            self._hoc_stimlist.count() - 1)
 
                     ppset = True
                     break
@@ -669,7 +671,7 @@ class Cell(object):
             if ppset:
                 break
 
-        return self.stimlist.count() - 1
+        return self._hoc_stimlist.count() - 1
 
     def _collect_geometry(self):
         """Collects x, y, z-coordinates from NEURON"""
@@ -1117,13 +1119,13 @@ class Cell(object):
         if rec_vmem:
             self._collect_vmem()
 
-        if hasattr(self, 'stimireclist'):
+        if hasattr(self, '_hoc_stimireclist'):
             self._collect_istim()
-        if hasattr(self, 'stimvreclist'):
+        if hasattr(self, '_hoc_stimvreclist'):
             self._collect_vstim()
-        if hasattr(self, 'synireclist'):
+        if hasattr(self, '_hoc_synireclist'):
             self._collect_isyn()
-        if hasattr(self, 'synvreclist'):
+        if hasattr(self, '_hoc_synvreclist'):
             self._collect_vsyn()
         if len(rec_variables) > 0:
             self._collect_rec_variables(rec_variables)
@@ -1182,37 +1184,37 @@ class Cell(object):
         Fetch the vectors from the memireclist and calculate self.imem
         containing all the membrane currents.
         """
-        self.imem = np.array(self.memireclist)
-        self.memireclist = None
-        del self.memireclist
+        self.imem = np.array(self._hoc_memireclist)
+        self._hoc_memireclist = None
+        del self._hoc_memireclist
 
     def _calc_ipas(self):
         """
         Get the passive currents
         """
-        self.ipas = np.array(self.memipasreclist)
+        self.ipas = np.array(self._hoc_memipasreclist)
         for i in range(self.ipas.shape[0]):
             self.ipas[i, ] *= self.area[i] * 1E-2
-        self.memipasreclist = None
-        del self.memipasreclist
+        self._hoc_memipasreclist = None
+        del self._hoc_memipasreclist
 
     def _calc_icap(self):
         """
         Get the capacitive currents
         """
-        self.icap = np.array(self.memicapreclist)
+        self.icap = np.array(self._hoc_memicapreclist)
         for i in range(self.icap.shape[0]):
             self.icap[i, ] *= self.area[i] * 1E-2
-        self.memicapreclist = None
-        del self.memicapreclist
+        self._hoc_memicapreclist = None
+        del self._hoc_memicapreclist
 
     def _collect_vmem(self):
         """
         Get the membrane currents
         """
-        self.vmem = np.array(self.memvreclist)
-        self.memvreclist = None
-        del self.memvreclist
+        self.vmem = np.array(self._hoc_memvreclist)
+        self._hoc_memvreclist = None
+        del self._hoc_memvreclist
 
     def _collect_isyn(self):
         """
@@ -1221,8 +1223,8 @@ class Cell(object):
         for syn in self.synapses:
             if syn.record_current:
                 syn.collect_current(self)
-        self.synireclist = None
-        del self.synireclist
+        self._hoc_synireclist = None
+        del self._hoc_synireclist
 
     def _collect_vsyn(self):
         """
@@ -1231,8 +1233,8 @@ class Cell(object):
         for syn in self.synapses:
             if syn.record_potential:
                 syn.collect_potential(self)
-        self.synvreclist = None
-        del self.synvreclist
+        self._hoc_synvreclist = None
+        del self._hoc_synvreclist
 
     def _collect_istim(self):
         """
@@ -1241,8 +1243,8 @@ class Cell(object):
         for pp in self.pointprocesses:
             if pp.record_current:
                 pp.collect_current(self)
-        self.stimireclist = None
-        del self.stimireclist
+        self._hoc_stimireclist = None
+        del self._hoc_stimireclist
 
     def _collect_vstim(self):
         """
@@ -1251,8 +1253,8 @@ class Cell(object):
         for pp in self.pointprocesses:
             if pp.record_potential:
                 pp.collect_potential(self)
-        self.stimvreclist = None
-        del self.stimvreclist
+        self._hoc_stimvreclist = None
+        del self._hoc_stimvreclist
 
     def _collect_rec_variables(self, rec_variables):
         """
@@ -1261,12 +1263,12 @@ class Cell(object):
         """
         self.rec_variables = {}
         i = 0
-        for values in self.recvariablesreclist:
+        for values in self._hoc_recvariablesreclist:
             self.rec_variables.update({rec_variables[i]: np.array(values)})
             if self.verbose:
                 print('collected recorded variable %s' % rec_variables[i])
             i += 1
-        del self.recvariablesreclist
+        del self._hoc_recvariablesreclist
 
     def _loadspikes(self):
         """
@@ -1330,7 +1332,7 @@ class Cell(object):
         """
         Record membrane currents for all segments
         """
-        self.memireclist = neuron.h.List()
+        self._hoc_memireclist = neuron.h.List()
         for sec in self.allseclist:
             for seg in sec:
                 if dt is not None:
@@ -1339,7 +1341,7 @@ class Cell(object):
                 else:
                     memirec = neuron.h.Vector()
                     memirec.record(seg._ref_i_membrane_)
-                self.memireclist.append(memirec)
+                self._hoc_memireclist.append(memirec)
 
     def _set_time_recorders(self, dt):
         """
@@ -1356,7 +1358,7 @@ class Cell(object):
         """
         Record passive membrane currents for all segments
         """
-        self.memipasreclist = neuron.h.List()
+        self._hoc_memipasreclist = neuron.h.List()
         for sec in self.allseclist:
             for seg in sec:
                 if dt is not None:
@@ -1365,13 +1367,13 @@ class Cell(object):
                 else:
                     memipasrec = neuron.h.Vector()
                     memipasrec.record(seg._ref_i_pas)
-                self.memipasreclist.append(memipasrec)
+                self._hoc_memipasreclist.append(memipasrec)
 
     def _set_icap_recorders(self, dt):
         """
         Record capacitive membrane currents for all segments
         """
-        self.memicapreclist = neuron.h.List()
+        self._hoc_memicapreclist = neuron.h.List()
         for sec in self.allseclist:
             for seg in sec:
                 if dt is not None:
@@ -1380,16 +1382,16 @@ class Cell(object):
                 else:
                     memicaprec = neuron.h.Vector()
                     memicaprec.record(seg._ref_i_cap)
-                self.memicapreclist.append(memicaprec)
+                self._hoc_memicapreclist.append(memicaprec)
 
     def _set_ipointprocess_recorders(self, dt):
         """
         Record point process current
         """
-        self.stimireclist = neuron.h.List()
+        self._hoc_stimireclist = neuron.h.List()
         for idx, pp in enumerate(self.pointprocesses):
             if idx in self._stimitorecord:
-                stim = self.stimlist[idx]
+                stim = self._hoc_stimlist[idx]
                 if dt is not None:
                     stimirec = neuron.h.Vector(int(self.tstop / self.dt + 1))
                     stimirec.record(stim._ref_i, self.dt)
@@ -1398,16 +1400,16 @@ class Cell(object):
                     stimirec.record(stim._ref_i)
             else:
                 stimirec = neuron.h.Vector(0)
-            self.stimireclist.append(stimirec)
+            self._hoc_stimireclist.append(stimirec)
 
     def _set_vpointprocess_recorders(self, dt):
         """
         Record point process membrane
         """
-        self.stimvreclist = neuron.h.List()
+        self._hoc_stimvreclist = neuron.h.List()
         for idx, pp in enumerate(self.pointprocesses):
             if idx in self._stimvtorecord:
-                stim = self.stimlist[idx]
+                stim = self._hoc_stimlist[idx]
                 seg = stim.get_segment()
                 if dt is not None:
                     stimvrec = neuron.h.Vector(int(self.tstop / self.dt + 1))
@@ -1417,13 +1419,13 @@ class Cell(object):
                     stimvrec.record(seg._ref_v)
             else:
                 stimvrec = neuron.h.Vector(0)
-            self.stimvreclist.append(stimvrec)
+            self._hoc_stimvreclist.append(stimvrec)
 
     def _set_isyn_recorders(self, dt):
         """
         Record point process current
         """
-        self.synireclist = neuron.h.List()
+        self._hoc_synireclist = neuron.h.List()
         for idx, pp in enumerate(self.synapses):
             if idx in self._synitorecord:
                 syn = self._hoc_synlist[idx]
@@ -1435,13 +1437,13 @@ class Cell(object):
                     synirec.record(syn._ref_i)
             else:
                 synirec = neuron.h.Vector(0)
-            self.synireclist.append(synirec)
+            self._hoc_synireclist.append(synirec)
 
     def _set_vsyn_recorders(self, dt):
         """
         Record point process membrane
         """
-        self.synvreclist = neuron.h.List()
+        self._hoc_synvreclist = neuron.h.List()
         for idx, pp in enumerate(self.synapses):
             if idx in self._synvtorecord:
                 syn = self._hoc_synlist[idx]
@@ -1454,13 +1456,13 @@ class Cell(object):
                     synvrec.record(seg._ref_v)
             else:
                 synvrec = neuron.h.Vector(0)
-            self.synvreclist.append(synvrec)
+            self._hoc_synvreclist.append(synvrec)
 
     def _set_voltage_recorders(self, dt):
         """
         Record membrane potentials for all segments
         """
-        self.memvreclist = neuron.h.List()
+        self._hoc_memvreclist = neuron.h.List()
         for sec in self.allseclist:
             for seg in sec:
                 if dt is not None:
@@ -1469,7 +1471,7 @@ class Cell(object):
                 else:
                     memvrec = neuron.h.Vector()
                     memvrec.record(seg._ref_v)
-                self.memvreclist.append(memvrec)
+                self._hoc_memvreclist.append(memvrec)
 
     def _set_current_dipole_moment_array(self, dt):
         """
@@ -1487,12 +1489,12 @@ class Cell(object):
         """
         Create a recorder for each variable name in list
         rec_variables
-        Variables is stored in nested list self.recvariablesreclist
+        Variables is stored in nested list self._hoc_recvariablesreclist
         """
-        self.recvariablesreclist = neuron.h.List()
+        self._hoc_recvariablesreclist = neuron.h.List()
         for variable in rec_variables:
             variablereclist = neuron.h.List()
-            self.recvariablesreclist.append(variablereclist)
+            self._hoc_recvariablesreclist.append(variablereclist)
             for sec in self.allseclist:
                 for seg in sec:
                     if dt is not None:

--- a/LFPy/cell.py
+++ b/LFPy/cell.py
@@ -553,8 +553,8 @@ class Cell(object):
         int
             index of synapse object on cell
         """
-        if not hasattr(self, 'synlist'):
-            self.synlist = neuron.h.List()
+        if not hasattr(self, '_hoc_synlist'):
+            self._hoc_synlist = neuron.h.List()
         if not hasattr(self, '_synitorecord'):
             self._synitorecord = []
         if not hasattr(self, '_synvtorecord'):
@@ -581,7 +581,7 @@ class Cell(object):
                             setattr(syn, param, kwargs[param])
                         except BaseException:
                             pass
-                    self.synlist.append(syn)
+                    self._hoc_synlist.append(syn)
 
                     # create NetStim (generator) and NetCon (connection)
                     # objects
@@ -594,15 +594,15 @@ class Cell(object):
 
                     # record current
                     if record_current:
-                        self._synitorecord.append(self.synlist.count() - 1)
+                        self._synitorecord.append(self._hoc_synlist.count() - 1)
 
                     # record potential
                     if record_potential:
-                        self._synvtorecord.append(self.synlist.count() - 1)
+                        self._synvtorecord.append(self._hoc_synlist.count() - 1)
 
                 i += 1
 
-        return self.synlist.count() - 1
+        return self._hoc_synlist.count() - 1
 
     def set_point_process(self, idx, pptype, record_current=False,
                           record_potential=False, **kwargs):
@@ -1270,9 +1270,9 @@ class Cell(object):
         """
         Initialize spiketimes from netcon if they exist
         """
-        if hasattr(self, 'synlist'):
-            if len(self.synlist) == len(self.sptimeslist):
-                for i in range(int(self.synlist.count())):
+        if hasattr(self, '_hoc_synlist'):
+            if len(self._hoc_synlist) == len(self.sptimeslist):
+                for i in range(int(self._hoc_synlist.count())):
                     for spt in self.sptimeslist[i]:
                         self._hoc_netconlist.o(i).event(spt)
 
@@ -1424,7 +1424,7 @@ class Cell(object):
         self.synireclist = neuron.h.List()
         for idx, pp in enumerate(self.synapses):
             if idx in self._synitorecord:
-                syn = self.synlist[idx]
+                syn = self._hoc_synlist[idx]
                 if dt is not None:
                     synirec = neuron.h.Vector(int(self.tstop / self.dt + 1))
                     synirec.record(syn._ref_i, self.dt)
@@ -1442,7 +1442,7 @@ class Cell(object):
         self.synvreclist = neuron.h.List()
         for idx, pp in enumerate(self.synapses):
             if idx in self._synvtorecord:
-                syn = self.synlist[idx]
+                syn = self._hoc_synlist[idx]
                 seg = syn.get_segment()
                 if dt is not None:
                     synvrec = neuron.h.Vector(int(self.tstop / self.dt + 1))

--- a/LFPy/cell.py
+++ b/LFPy/cell.py
@@ -559,8 +559,8 @@ class Cell(object):
             self._synitorecord = []
         if not hasattr(self, '_synvtorecord'):
             self._synvtorecord = []
-        if not hasattr(self, 'netstimlist'):
-            self.netstimlist = neuron.h.List()
+        if not hasattr(self, '_hoc_netstimlist'):
+            self._hoc_netstimlist = neuron.h.List()
         if not hasattr(self, 'netconlist'):
             self.netconlist = neuron.h.List()
         if not hasattr(self, 'sptimeslist'):
@@ -585,10 +585,10 @@ class Cell(object):
 
                     # create NetStim (generator) and NetCon (connection)
                     # objects
-                    self.netstimlist.append(neuron.h.NetStim(0.5))
-                    self.netstimlist[-1].number = 0
+                    self._hoc_netstimlist.append(neuron.h.NetStim(0.5))
+                    self._hoc_netstimlist[-1].number = 0
 
-                    nc = neuron.h.NetCon(self.netstimlist[-1], syn)
+                    nc = neuron.h.NetCon(self._hoc_netstimlist[-1], syn)
                     nc.weight[0] = weight
                     self.netconlist.append(nc)
 
@@ -1125,10 +1125,10 @@ class Cell(object):
             self._collect_vsyn()
         if len(rec_variables) > 0:
             self._collect_rec_variables(rec_variables)
-        if hasattr(self, 'netstimlist'):
-            # self.netstimlist.remove_all()
-            self.netstimlist = None
-            del self.netstimlist
+        if hasattr(self, '_hoc_netstimlist'):
+            # self._hoc_netstimlist.remove_all()
+            self._hoc_netstimlist = None
+            del self._hoc_netstimlist
 
     def _run_simulation(self, cvode, variable_dt=False, atol=0.001, rtol=0.):
         """

--- a/LFPy/cell.py
+++ b/LFPy/cell.py
@@ -564,7 +564,10 @@ class Cell(object):
         if not hasattr(self, 'netconlist'):
             self.netconlist = neuron.h.List()
         if not hasattr(self, 'sptimeslist'):
-            self.sptimeslist = neuron.h.List()
+            self.sptimeslist = []
+
+        # need to append w. one empty array per synapse
+        self.sptimeslist.append(np.array([]))
 
         i = 0
         cmd = 'neuron.h.{}(seg.x, sec=sec)'
@@ -1123,6 +1126,7 @@ class Cell(object):
         if len(rec_variables) > 0:
             self._collect_rec_variables(rec_variables)
         if hasattr(self, 'netstimlist'):
+            # self.netstimlist.remove_all()
             self.netstimlist = None
             del self.netstimlist
 
@@ -1269,9 +1273,8 @@ class Cell(object):
         if hasattr(self, 'synlist'):
             if len(self.synlist) == len(self.sptimeslist):
                 for i in range(int(self.synlist.count())):
-                    for ii in range(int(self.sptimeslist.o(i).size)):
-                        self.netconlist.o(i).event(
-                            float(self.sptimeslist.o(i)[ii]))
+                    for spt in self.sptimeslist[i]:
+                        self.netconlist.o(i).event(spt)
 
     def _set_soma_volt_recorder(self, dt):
         """Record somatic membrane potential"""

--- a/LFPy/cell.py
+++ b/LFPy/cell.py
@@ -594,11 +594,13 @@ class Cell(object):
 
                     # record current
                     if record_current:
-                        self._synitorecord.append(self._hoc_synlist.count() - 1)
+                        self._synitorecord.append(
+                            self._hoc_synlist.count() - 1)
 
                     # record potential
                     if record_potential:
-                        self._synvtorecord.append(self._hoc_synlist.count() - 1)
+                        self._synvtorecord.append(
+                            self._hoc_synlist.count() - 1)
 
                 i += 1
 

--- a/LFPy/network.py
+++ b/LFPy/network.py
@@ -525,8 +525,8 @@ class Network(object):
         self.pc = neuron.h.ParallelContext()
 
         # create empty list for connections between cells (not to be confused
-        # with each cell's list of netcons)
-        self.netconlist = neuron.h.List()
+        # with each cell's list of netcons _hoc_netconlist)
+        self._hoc_netconlist = neuron.h.List()
 
         # The different populations in the Network will be collected in
         # a dictionary of NetworkPopulation object, where the keys represent
@@ -823,7 +823,7 @@ class Network(object):
                     nc = self.pc.gid_connect(gid_pre, cell.netconsynapses[-1])
                     nc.weight[0] = weight
                     nc.delay = delays[i]
-                    self.netconlist.append(nc)
+                    self._hoc_netconlist.append(nc)
 
                     # store also synapse indices allowing for computing LFPs
                     # from syn.i

--- a/LFPy/network.py
+++ b/LFPy/network.py
@@ -137,7 +137,7 @@ class NetworkCell(TemplateCell):
         TemplateCell.__init__(self, **args)
 
         # create list netconlist for spike detecting NetCon object(s)
-        self.sd_netconlist = neuron.h.List()
+        self._hoc_sd_netconlist = neuron.h.List()
         # create list of recording device for action potentials
         self.spikes = []
         # create list of random number generators used with synapse model
@@ -219,9 +219,9 @@ class NetworkCell(TemplateCell):
         Create spike-detecting NetCon object attached to the cell's soma
         midpoint, but this could be extended to having multiple spike-detection
         sites. The NetCon object created is attached to the cell's
-        sd_netconlist attribute, and will be used by the Network class when
-        creating connections between all presynaptic cells and postsynaptic
-        cells on each local RANK.
+        `_hoc_sd_netconlist` attribute, and will be used by the Network class
+        when creating connections between all presynaptic cells and
+        postsynaptic cells on each local RANK.
 
         Parameters
         ----------
@@ -236,12 +236,12 @@ class NetworkCell(TemplateCell):
         # create new NetCon objects for the connections. Activation times will
         # be triggered on the somatic voltage with a given threshold.
         for sec in self.somalist:
-            self.sd_netconlist.append(neuron.h.NetCon(sec(0.5)._ref_v,
-                                                      target,
-                                                      sec=sec))
-            self.sd_netconlist[-1].threshold = threshold
-            self.sd_netconlist[-1].weight[0] = weight
-            self.sd_netconlist[-1].delay = delay
+            self._hoc_sd_netconlist.append(neuron.h.NetCon(sec(0.5)._ref_v,
+                                                           target,
+                                                           sec=sec))
+            self._hoc_sd_netconlist[-1].threshold = threshold
+            self._hoc_sd_netconlist[-1].weight[0] = weight
+            self._hoc_sd_netconlist[-1].delay = delay
 
 
 class DummyCell(object):
@@ -604,11 +604,11 @@ class Network(object):
             # target to cell gid
             cell.create_spike_detector(None)
             # assosiate cell gid with the NetCon source
-            self.pc.cell(gid, cell.sd_netconlist[-1])
+            self.pc.cell(gid, cell._hoc_sd_netconlist[-1])
 
             # record spike events
             population.spike_vectors.append(neuron.h.Vector())
-            cell.sd_netconlist[-1].record(population.spike_vectors[-1])
+            cell._hoc_sd_netconlist[-1].record(population.spike_vectors[-1])
 
         # add population object to dictionary of populations
         self.populations[name] = population

--- a/LFPy/network.py
+++ b/LFPy/network.py
@@ -1058,8 +1058,8 @@ class Network(object):
                     cell._collect_istim()
                 if len(rec_variables) > 0:
                     cell._collect_rec_variables(rec_variables)
-                if hasattr(cell, 'netstimlist'):
-                    del cell.netstimlist
+                if hasattr(cell, '_hoc_netstimlist'):
+                    del cell._hoc_netstimlist
 
         # Collect spike trains across all RANKs to RANK 0
         for name in self.population_names:

--- a/LFPy/pointprocess.py
+++ b/LFPy/pointprocess.py
@@ -196,7 +196,7 @@ class Synapse(PointProcess):
         cell: LFPy.Cell like object
         """
         try:
-            self.i = np.array(cell.synireclist.o(self.hocidx))
+            self.i = np.array(cell._hoc_synireclist.o(self.hocidx))
         except BaseException:
             raise Exception('cell.synireclist deleted from consequtive runs')
 
@@ -209,7 +209,7 @@ class Synapse(PointProcess):
         cell: LFPy.Cell like object
         """
         try:
-            self.v = np.array(cell.synvreclist.o(self.hocidx))
+            self.v = np.array(cell._hoc_synvreclist.o(self.hocidx))
         except BaseException:
             raise Exception('cell.synvreclist deleted from consequtive runs')
 
@@ -327,7 +327,7 @@ class StimIntElectrode(PointProcess):
         ----------
         cell: LFPy.Cell like object
         """
-        self.i = np.array(cell.stimireclist.o(self.hocidx))
+        self.i = np.array(cell._hoc_stimireclist.o(self.hocidx))
 
     def collect_potential(self, cell):
         """Collect membrane potential of segment with PointProcess.
@@ -337,4 +337,4 @@ class StimIntElectrode(PointProcess):
         ----------
         cell: LFPy.Cell like object
         """
-        self.v = np.array(cell.stimvreclist.o(self.hocidx))
+        self.v = np.array(cell._hoc_stimvreclist.o(self.hocidx))

--- a/LFPy/pointprocess.py
+++ b/LFPy/pointprocess.py
@@ -145,7 +145,7 @@ class Synapse(PointProcess):
                                            record_current=record_current,
                                            record_potential=record_potential,
                                            **kwargs))
-        self._ns_index = int(cell.netstimlist.count()) - 1
+        self._ns_index = int(cell._hoc_netstimlist.count()) - 1
         cell.synapses.append(self)
         cell.synidx.append(idx)
 
@@ -182,11 +182,11 @@ class Synapse(PointProcess):
         seed: float
             Random seed value
         """
-        self.cell.netstimlist[self._ns_index].noise = noise
-        self.cell.netstimlist[self._ns_index].start = start
-        self.cell.netstimlist[self._ns_index].number = number
-        self.cell.netstimlist[self._ns_index].interval = interval
-        self.cell.netstimlist[self._ns_index].seed(seed)
+        self.cell._hoc_netstimlist[self._ns_index].noise = noise
+        self.cell._hoc_netstimlist[self._ns_index].start = start
+        self.cell._hoc_netstimlist[self._ns_index].number = number
+        self.cell._hoc_netstimlist[self._ns_index].interval = interval
+        self.cell._hoc_netstimlist[self._ns_index].seed(seed)
 
     def collect_current(self, cell):
         """Collect synapse current. Sets ``<synapse>.i``

--- a/LFPy/pointprocess.py
+++ b/LFPy/pointprocess.py
@@ -148,7 +148,6 @@ class Synapse(PointProcess):
         self._ns_index = int(cell.netstimlist.count()) - 1
         cell.synapses.append(self)
         cell.synidx.append(idx)
-        self.cell.sptimeslist.append(np.array([]))
 
     def set_spike_times(self, sptimes=np.zeros(0)):
         """Set the spike times explicitly using numpy arrays
@@ -161,8 +160,7 @@ class Synapse(PointProcess):
         assert isinstance(sptimes, np.ndarray), \
             'synapse activation times must be ndarray, not ({})'.format(
                 type(sptimes))
-        self.cell.sptimeslist.insrt(self._ns_index, sptimes)
-        self.cell.sptimeslist.remove(self._ns_index + 1)
+        self.cell.sptimeslist[self._ns_index] = sptimes
 
     def set_spike_times_w_netstim(self, noise=1., start=0., number=1E3,
                                   interval=10., seed=1234.):

--- a/LFPy/test/test_cell.py
+++ b/LFPy/test/test_cell.py
@@ -644,10 +644,10 @@ class testCell(unittest.TestCase):
                                                  'ball_and_sticks.hoc'))
         cell.set_point_process(idx=0, pptype='IClamp', record_current=False,
                                **dict(delay=1., amp=1.))
-        self.assertEqual(cell.stimlist[0].hname(), 'IClamp[0]')
-        self.assertEqual(len(cell.stimlist), 1)
-        self.assertEqual(cell.stimlist[0].delay, 1.)
-        self.assertEqual(cell.stimlist[0].amp, 1.)
+        self.assertEqual(cell._hoc_stimlist[0].hname(), 'IClamp[0]')
+        self.assertEqual(len(cell._hoc_stimlist), 1)
+        self.assertEqual(cell._hoc_stimlist[0].delay, 1.)
+        self.assertEqual(cell._hoc_stimlist[0].amp, 1.)
 
     def test_cell_strip_hoc_objects_00(self):
         cell = LFPy.Cell(morphology=os.path.join(LFPy.__path__[0], 'test',

--- a/LFPy/test/test_cell.py
+++ b/LFPy/test/test_cell.py
@@ -631,12 +631,12 @@ class testCell(unittest.TestCase):
                          record_potential=False, weight=1.,
                          **dict(e=10., tau=2.))
 
-        self.assertTrue('ExpSyn' in cell.synlist[0].hname())
-        self.assertEqual(len(cell.synlist), 1)
+        self.assertTrue('ExpSyn' in cell._hoc_synlist[0].hname())
+        self.assertEqual(len(cell._hoc_synlist), 1)
         self.assertEqual(len(cell._hoc_netconlist), 1)
         self.assertEqual(len(cell._hoc_netstimlist), 1)
-        self.assertEqual(cell.synlist[0].e, 10.)
-        self.assertEqual(cell.synlist[0].tau, 2.)
+        self.assertEqual(cell._hoc_synlist[0].e, 10.)
+        self.assertEqual(cell._hoc_synlist[0].tau, 2.)
         self.assertEqual(cell._hoc_netconlist[0].weight[0], 1.)
 
     def test_cell_set_point_process_00(self):

--- a/LFPy/test/test_cell.py
+++ b/LFPy/test/test_cell.py
@@ -633,11 +633,11 @@ class testCell(unittest.TestCase):
 
         self.assertTrue('ExpSyn' in cell.synlist[0].hname())
         self.assertEqual(len(cell.synlist), 1)
-        self.assertEqual(len(cell.netconlist), 1)
+        self.assertEqual(len(cell._hoc_netconlist), 1)
         self.assertEqual(len(cell._hoc_netstimlist), 1)
         self.assertEqual(cell.synlist[0].e, 10.)
         self.assertEqual(cell.synlist[0].tau, 2.)
-        self.assertEqual(cell.netconlist[0].weight[0], 1.)
+        self.assertEqual(cell._hoc_netconlist[0].weight[0], 1.)
 
     def test_cell_set_point_process_00(self):
         cell = LFPy.Cell(morphology=os.path.join(LFPy.__path__[0], 'test',

--- a/LFPy/test/test_cell.py
+++ b/LFPy/test/test_cell.py
@@ -634,7 +634,7 @@ class testCell(unittest.TestCase):
         self.assertTrue('ExpSyn' in cell.synlist[0].hname())
         self.assertEqual(len(cell.synlist), 1)
         self.assertEqual(len(cell.netconlist), 1)
-        self.assertEqual(len(cell.netstimlist), 1)
+        self.assertEqual(len(cell._hoc_netstimlist), 1)
         self.assertEqual(cell.synlist[0].e, 10.)
         self.assertEqual(cell.synlist[0].tau, 2.)
         self.assertEqual(cell.netconlist[0].weight[0], 1.)

--- a/LFPy/test/test_networkcell.py
+++ b/LFPy/test/test_networkcell.py
@@ -902,12 +902,12 @@ class testNetworkCell(unittest.TestCase):
                          record_potential=False, weight=1.,
                          **dict(e=10., tau=2.))
 
-        self.assertTrue('ExpSyn' in cell.synlist[0].hname())
-        self.assertEqual(len(cell.synlist), 1)
+        self.assertTrue('ExpSyn' in cell._hoc_synlist[0].hname())
+        self.assertEqual(len(cell._hoc_synlist), 1)
         self.assertEqual(len(cell._hoc_netconlist), 1)
         self.assertEqual(len(cell._hoc_netstimlist), 1)
-        self.assertEqual(cell.synlist[0].e, 10.)
-        self.assertEqual(cell.synlist[0].tau, 2.)
+        self.assertEqual(cell._hoc_synlist[0].e, 10.)
+        self.assertEqual(cell._hoc_synlist[0].tau, 2.)
         self.assertEqual(cell._hoc_netconlist[0].weight[0], 1.)
 
     def test_cell_set_point_process_00(self):

--- a/LFPy/test/test_networkcell.py
+++ b/LFPy/test/test_networkcell.py
@@ -905,7 +905,7 @@ class testNetworkCell(unittest.TestCase):
         self.assertTrue('ExpSyn' in cell.synlist[0].hname())
         self.assertEqual(len(cell.synlist), 1)
         self.assertEqual(len(cell.netconlist), 1)
-        self.assertEqual(len(cell.netstimlist), 1)
+        self.assertEqual(len(cell._hoc_netstimlist), 1)
         self.assertEqual(cell.synlist[0].e, 10.)
         self.assertEqual(cell.synlist[0].tau, 2.)
         self.assertEqual(cell.netconlist[0].weight[0], 1.)

--- a/LFPy/test/test_networkcell.py
+++ b/LFPy/test/test_networkcell.py
@@ -925,10 +925,10 @@ class testNetworkCell(unittest.TestCase):
         )
         cell.set_point_process(idx=0, pptype='IClamp', record_current=False,
                                **dict(delay=1., amp=1.))
-        self.assertEqual(cell.stimlist[0].hname(), 'IClamp[0]')
-        self.assertEqual(len(cell.stimlist), 1)
-        self.assertEqual(cell.stimlist[0].delay, 1.)
-        self.assertEqual(cell.stimlist[0].amp, 1.)
+        self.assertEqual(cell._hoc_stimlist[0].hname(), 'IClamp[0]')
+        self.assertEqual(len(cell._hoc_stimlist), 1)
+        self.assertEqual(cell._hoc_stimlist[0].delay, 1.)
+        self.assertEqual(cell._hoc_stimlist[0].amp, 1.)
 
     def test_cell_strip_hoc_objects_00(self):
         cell = LFPy.NetworkCell(

--- a/LFPy/test/test_networkcell.py
+++ b/LFPy/test/test_networkcell.py
@@ -904,11 +904,11 @@ class testNetworkCell(unittest.TestCase):
 
         self.assertTrue('ExpSyn' in cell.synlist[0].hname())
         self.assertEqual(len(cell.synlist), 1)
-        self.assertEqual(len(cell.netconlist), 1)
+        self.assertEqual(len(cell._hoc_netconlist), 1)
         self.assertEqual(len(cell._hoc_netstimlist), 1)
         self.assertEqual(cell.synlist[0].e, 10.)
         self.assertEqual(cell.synlist[0].tau, 2.)
-        self.assertEqual(cell.netconlist[0].weight[0], 1.)
+        self.assertEqual(cell._hoc_netconlist[0].weight[0], 1.)
 
     def test_cell_set_point_process_00(self):
         cell = LFPy.NetworkCell(

--- a/LFPy/test/test_templatecell.py
+++ b/LFPy/test/test_templatecell.py
@@ -905,7 +905,7 @@ class testTemplateCell(unittest.TestCase):
         self.assertTrue('ExpSyn' in cell.synlist[0].hname())
         self.assertEqual(len(cell.synlist), 1)
         self.assertEqual(len(cell.netconlist), 1)
-        self.assertEqual(len(cell.netstimlist), 1)
+        self.assertEqual(len(cell._hoc_netstimlist), 1)
         self.assertEqual(cell.synlist[0].e, 10.)
         self.assertEqual(cell.synlist[0].tau, 2.)
         self.assertEqual(cell.netconlist[0].weight[0], 1.)

--- a/LFPy/test/test_templatecell.py
+++ b/LFPy/test/test_templatecell.py
@@ -904,11 +904,11 @@ class testTemplateCell(unittest.TestCase):
 
         self.assertTrue('ExpSyn' in cell.synlist[0].hname())
         self.assertEqual(len(cell.synlist), 1)
-        self.assertEqual(len(cell.netconlist), 1)
+        self.assertEqual(len(cell._hoc_netconlist), 1)
         self.assertEqual(len(cell._hoc_netstimlist), 1)
         self.assertEqual(cell.synlist[0].e, 10.)
         self.assertEqual(cell.synlist[0].tau, 2.)
-        self.assertEqual(cell.netconlist[0].weight[0], 1.)
+        self.assertEqual(cell._hoc_netconlist[0].weight[0], 1.)
 
     def test_cell_set_point_process_00(self):
         cell = LFPy.TemplateCell(

--- a/LFPy/test/test_templatecell.py
+++ b/LFPy/test/test_templatecell.py
@@ -902,12 +902,12 @@ class testTemplateCell(unittest.TestCase):
                          record_potential=False, weight=1.,
                          **dict(e=10., tau=2.))
 
-        self.assertTrue('ExpSyn' in cell.synlist[0].hname())
-        self.assertEqual(len(cell.synlist), 1)
+        self.assertTrue('ExpSyn' in cell._hoc_synlist[0].hname())
+        self.assertEqual(len(cell._hoc_synlist), 1)
         self.assertEqual(len(cell._hoc_netconlist), 1)
         self.assertEqual(len(cell._hoc_netstimlist), 1)
-        self.assertEqual(cell.synlist[0].e, 10.)
-        self.assertEqual(cell.synlist[0].tau, 2.)
+        self.assertEqual(cell._hoc_synlist[0].e, 10.)
+        self.assertEqual(cell._hoc_synlist[0].tau, 2.)
         self.assertEqual(cell._hoc_netconlist[0].weight[0], 1.)
 
     def test_cell_set_point_process_00(self):

--- a/LFPy/test/test_templatecell.py
+++ b/LFPy/test/test_templatecell.py
@@ -925,10 +925,10 @@ class testTemplateCell(unittest.TestCase):
         )
         cell.set_point_process(idx=0, pptype='IClamp', record_current=False,
                                **dict(delay=1., amp=1.))
-        self.assertEqual(cell.stimlist[0].hname(), 'IClamp[0]')
-        self.assertEqual(len(cell.stimlist), 1)
-        self.assertEqual(cell.stimlist[0].delay, 1.)
-        self.assertEqual(cell.stimlist[0].amp, 1.)
+        self.assertEqual(cell._hoc_stimlist[0].hname(), 'IClamp[0]')
+        self.assertEqual(len(cell._hoc_stimlist), 1)
+        self.assertEqual(cell._hoc_stimlist[0].delay, 1.)
+        self.assertEqual(cell._hoc_stimlist[0].amp, 1.)
 
     def test_cell_strip_hoc_objects_00(self):
         cell = LFPy.TemplateCell(

--- a/LFPy/test/test_templatecell.py
+++ b/LFPy/test/test_templatecell.py
@@ -879,7 +879,7 @@ class testTemplateCell(unittest.TestCase):
         self.assertAlmostEqual(
             np.corrcoef(
                 cell.area, hist)[
-                0, 1], 1., places=5)
+                0, 1], 1., places=4)
 
         # check if min and max is in the range of segment indices
         self.assertEqual(idx.min(), 0)


### PR DESCRIPTION
Renamed `Class.somelist = neuron.h.List()` as `Class._hoc_somelist` as they are usually not supposed to be accessed directly. 

Closes #296 