### PR TITLE
fix for h5py < 3

### DIFF
--- a/LFPy/test/test_network.py
+++ b/LFPy/test/test_network.py
@@ -714,8 +714,12 @@ class testNetwork(unittest.TestCase):
 
         # check static connection parameters
         synparams = f['synparams']['test:test']
-        assert synparams['mechanism'][()].decode() == \
-            connectionParameters['syntype'].__str__().strip('()')
+        if h5py.__version__ < '3':
+            assert synparams['mechanism'][()] == \
+                connectionParameters['syntype'].__str__().strip('()')
+        else:
+            assert synparams['mechanism'][()].decode() == \
+                connectionParameters['syntype'].__str__().strip('()')
         for key, value in connectionParameters['synparams'].items():
             assert synparams[key][()] == value
 


### PR DESCRIPTION
Closes #310. Tested on JUSUF w. Python 3.8.5 and h5py 2.10