### PR TITLE
Incorporate InfiniteHomogeneousVolCondMEG and SphericallySymmetricVolCondMEG

### DIFF
--- a/LFPy/__init__.py
+++ b/LFPy/__init__.py
@@ -68,7 +68,8 @@ from .templatecell import TemplateCell
 from .network import NetworkCell, NetworkPopulation, Network
 from .test import _test as run_tests
 from .eegmegcalc import FourSphereVolumeConductor, InfiniteVolumeConductor, \
-    MEG, NYHeadModel
+    MEG, InfiniteHomogeneousVolCondMEG, SphericallySymmetricVolCondMEG, \
+    NYHeadModel
 from lfpykit import lfpcalc
 from . import tools
 from . import inputgenerators

--- a/LFPy/eegmegcalc.py
+++ b/LFPy/eegmegcalc.py
@@ -16,6 +16,7 @@ GNU General Public License for more details.
 import lfpykit
 from lfpykit.eegmegcalc import NYHeadModel  # noqa: F401
 import numpy as np
+from warnings import warn
 
 
 class FourSphereVolumeConductor(lfpykit.eegmegcalc.FourSphereVolumeConductor):
@@ -273,7 +274,19 @@ class InfiniteVolumeConductor(lfpykit.eegmegcalc.InfiniteVolumeConductor):
         return potentials
 
 
-class MEG(lfpykit.eegmegcalc.MEG):
+class MEG(lfpykit.eegmegcalc.InfiniteHomogeneousVolCondMEG):
+    def __init__(self, sensor_locations, mu=4 * np.pi * 1E-7):
+        warn(
+            "class MEG is deprecated and will be removed. Use "
+            "InfiniteHomogeneousVolCondMEG or SphericallySymmetricVolCondMEG "
+            "instead",
+            DeprecationWarning, 2
+        )
+        super().__init__(sensor_locations, mu)
+
+
+class InfiniteHomogeneousVolCondMEG(
+        lfpykit.eegmegcalc.InfiniteHomogeneousVolCondMEG):
     """
     Basic class for computing magnetic field from current dipole moment.
     For this purpose we use the Biot-Savart law derived from Maxwell's
@@ -319,7 +332,8 @@ class MEG(lfpykit.eegmegcalc.MEG):
     Define cell object, create synapse, compute current dipole moment:
 
     >>> import LFPy, os, numpy as np, matplotlib.pyplot as plt
-    >>> from LFPy import MEG
+    >>> from LFPy import InfiniteHomogeneousVolCondMEG as MEG
+    >>> from LFPy import CurrentDipoleMoment
     >>> # create LFPy.Cell object
     >>> cell = LFPy.Cell(morphology=os.path.join(LFPy.__path__[0], 'test',
     >>>                                          'ball_and_sticks.hoc'),
@@ -330,17 +344,18 @@ class MEG(lfpykit.eegmegcalc.MEG):
     >>>                    record_current=True)
     >>> syn.set_spike_times_w_netstim()
     >>> # simulate, record current dipole moment
-    >>> cell.simulate(rec_current_dipole_moment=True)
+    >>> cdm = CurrentDipoleMoment(cell=cell)
+    >>> cell.simulate(probes=[cdm])
     >>> # Compute the dipole location as an average of segment locations
     >>> # weighted by membrane area:
-    >>> dipole_location = (cell.area * np.c_[cell.xmid, cell.ymid, cell.zmid].T
+    >>> dipole_location = (cell.area * np.c_[cell.x.mean(axis=1), cell.y.mean(axis=1), cell.z.mean(axis=1)].T
     >>>                    / cell.area.sum()).sum(axis=1)
     >>> # Define sensor site, instantiate MEG object, get transformation matrix
     >>> sensor_locations = np.array([[1E4, 0, 0]])
     >>> meg = MEG(sensor_locations)
     >>> M = meg.get_transformation_matrix(dipole_location)
     >>> # compute the magnetic signal in a single sensor location:
-    >>> H = M @ cell.current_dipole_moment.T
+    >>> H = M @ cdm.data
     >>> # plot output
     >>> plt.figure(figsize=(12, 8), dpi=120)
     >>> plt.subplot(311)
@@ -390,7 +405,7 @@ class MEG(lfpykit.eegmegcalc.MEG):
         Define cell object, create synapse, compute current dipole moment:
 
         >>> import LFPy, os, numpy as np, matplotlib.pyplot as plt
-        >>> from lfpykit.eegmegcalc import MEG
+        >>> from LFPy import InfiniteHomogeneousVolCondMEG as MEG
         >>> cell = LFPy.Cell(morphology=os.path.join(LFPy.__path__[0], 'test',
         >>>                                          'ball_and_sticks.hoc'),
         >>>                  passive=True)
@@ -420,6 +435,160 @@ class MEG(lfpykit.eegmegcalc.MEG):
         """
         i_axial, d_vectors, pos_vectors = cell.get_axial_currents_from_vmem()
         R = self.sensor_locations
+        H = np.zeros((R.shape[0], 3, cell.tvec.size))
+
+        for i, R_ in enumerate(R):
+            for i_, d_, r_ in zip(i_axial, d_vectors.T, pos_vectors):
+                r_rel = R_ - r_
+                H[i, :, :] += (i_.reshape((-1, 1))
+                               @ np.cross(d_, r_rel).reshape((1, -1))).T \
+                    / (4 * np.pi * np.sqrt((r_rel**2).sum())**3)
+        return H
+
+
+class SphericallySymmetricVolCondMEG(
+        lfpykit.eegmegcalc.SphericallySymmetricVolCondMEG):
+    """Computes magnetic fields from current dipole in
+    spherically-symmetric volume conductor models.
+
+    This class facilitates calculations according to eq. (34) from [1]_
+    (see also [2]_) defined as:
+
+    .. math::
+
+        \\mathbf{H} = \\frac{1}{4 \\pi} \\frac{F \\mathbf{p} \\times
+        \\mathbf{r}_p - (\\mathbf{p} \\times \\mathbf{r}_p \\cdot
+        \\mathbf{r}) \\nabla F}{F^2},
+        \\text{ where}
+
+        F = a(ra + r^2 - \\mathbf{r}_p \\cdot \\mathbf{r}),
+
+        \\nabla F = (r^{-1}a^2 + a^{-1}\\mathbf{a}
+        \\cdot \\mathbf{r} + 2a + 2r)\\mathbf{r}
+        -(a + 2r + a^{-1}\\mathbf{a} \\cdot \\mathbf{r})\\mathbf{r}_p,
+
+        \\mathbf{a} = \\mathbf{r} - \\mathbf{r}_p,
+
+        a = |\\mathbf{a}|,
+
+        r = |\\mathbf{r}| .
+
+    Here,
+    :math:`\\mathbf{p}` is the current dipole moment,
+    :math:`\\mathbf{r}` the measurement location(s) and
+    :math:`\\mathbf{r}_p` the current dipole location.
+
+    Note that the magnetic field :math:`\\mathbf{H}` is related to the magnetic
+    field :math:`\\mathbf{B}` as
+
+    .. math:: \\mu_0 \\mathbf{H} = \\mathbf{B}-\\mathbf{M} ,
+
+    where :math:`\\mu_0` denotes the permeability of free space (very close to
+    permebility of biological tissues).
+    :math:`\\mathbf{M}` denotes material
+    magnetization (which is ignored).
+
+    Parameters
+    ----------
+    r: ndarray
+        sensor locations, shape ``(n, 3)`` where ``n`` denotes number of
+        locations, unit [µm]
+    mu: float
+        Permeability. Default is permeability of vacuum
+        (:math:`\\mu_0 = 4\\pi 10^{-7}` Tm/A)
+
+    See also
+    --------
+    InfiniteHomogeneousVolCondMEG
+
+    Examples
+    --------
+    Compute the magnetic field from a current dipole located
+
+    >>> import numpy as np
+    >>> from LFPy import SphericallySymmetricVolCondMEG
+    >>> p = np.array([[0, 1, 0]]).T  # tangential current dipole (nAµm)
+    >>> r_p = np.array([0, 0, 90000])  # dipole location (µm)
+    >>> r = np.array([[0, 0, 92000]])  # measurement location (µm)
+    >>> m = SphericallySymmetricVolCondMEG(r=r)
+    >>> M = m.get_transformation_matrix(r_p=r_p)
+    >>> H = M @ p
+    >>> H  # magnetic field (nA/µm)
+    array([[[9.73094081e-09],
+            [0.00000000e+00],
+            [0.00000000e+00]]])
+
+    References
+    ----------
+    .. [1] Hämäläinen M., et al., Reviews of Modern Physics, Vol. 65, No. 2,
+        April 1993.
+    .. [2] Sarvas J., Phys.Med. Biol., 1987, Vol. 32, No 1, 11-22.
+
+    Raises
+    ------
+    AssertionError
+        If dimensionality of sensor locations ``r`` is wrong
+    """
+
+    def __init__(self, r, mu=4 * np.pi * 1E-7):
+        super().__init__(r=r, mu=mu)
+
+    def calculate_H_from_iaxial(self, cell):
+        """
+        Computes the magnetic field in space from axial currents computed from
+        membrane potential values and axial resistances of multicompartment
+        cells.
+
+        See [1]_ for details on the biophysics governing magnetic fields from
+        axial currents.
+
+        Parameters
+        ----------
+        cell: object
+            LFPy.Cell-like object. Must have attribute vmem containing recorded
+            membrane potentials in units of mV
+
+        References
+        ----------
+        .. [1] Blagoev et al. (2007) Modelling the magnetic signature of
+            neuronal tissue. NeuroImage 37 (2007) 137–148
+            DOI: 10.1016/j.neuroimage.2007.04.033
+
+        Examples
+        --------
+        Define cell object, create synapse, compute current dipole moment:
+
+        >>> import LFPy, os, numpy as np, matplotlib.pyplot as plt
+        >>> from LFPy import SphericallySymmetricVolCondMEG as MEG
+        >>> cell = LFPy.Cell(morphology=os.path.join(LFPy.__path__[0], 'test',
+        >>>                                          'ball_and_sticks.hoc'),
+        >>>                  passive=True)
+        >>> cell.set_pos(0., 0., 0.)
+        >>> syn = LFPy.Synapse(cell, idx=0, syntype='ExpSyn', weight=0.01,
+        >>>                    record_current=True)
+        >>> syn.set_spike_times_w_netstim()
+        >>> cell.simulate(rec_vmem=True)
+        >>> # Instantiate the MEG object, compute and plot the magnetic
+        >>> # signal in a sensor location:
+        >>> r = np.array([[1E4, 0, 0]])
+        >>> meg = MEG(r)
+        >>> H = meg.calculate_H_from_iaxial(cell)
+        >>> plt.subplot(311)
+        >>> plt.plot(cell.tvec, cell.somav)
+        >>> plt.subplot(312)
+        >>> plt.plot(cell.tvec, syn.i)
+        >>> plt.subplot(313)
+        >>> plt.plot(cell.tvec, H[0, 1, :])  # y-component
+        >>> plt.show()
+
+        Returns
+        -------
+        H: ndarray, dtype=float
+            shape (n_locations x 3 x n_timesteps) array with x,y,z-components
+            of the magnetic field :math:`\\mathbf{H}` in units of (nA/µm)
+        """
+        i_axial, d_vectors, pos_vectors = cell.get_axial_currents_from_vmem()
+        R = self.r
         H = np.zeros((R.shape[0], 3, cell.tvec.size))
 
         for i, R_ in enumerate(R):

--- a/LFPy/eegmegcalc.py
+++ b/LFPy/eegmegcalc.py
@@ -348,7 +348,9 @@ class InfiniteHomogeneousVolCondMEG(
     >>> cell.simulate(probes=[cdm])
     >>> # Compute the dipole location as an average of segment locations
     >>> # weighted by membrane area:
-    >>> dipole_location = (cell.area * np.c_[cell.x.mean(axis=1), cell.y.mean(axis=1), cell.z.mean(axis=1)].T
+    >>> dipole_location = (cell.area * np.c_[cell.x.mean(axis=1),
+    >>>                                      cell.y.mean(axis=1),
+    >>>                                      cell.z.mean(axis=1)].T
     >>>                    / cell.area.sum()).sum(axis=1)
     >>> # Define sensor site, instantiate MEG object, get transformation matrix
     >>> sensor_locations = np.array([[1E4, 0, 0]])

--- a/LFPy/test/test_eegmegcalc.py
+++ b/LFPy/test/test_eegmegcalc.py
@@ -22,12 +22,12 @@ import LFPy
 import neuron
 
 
-class testMEG(unittest.TestCase):
+class testInfiniteHomogeneousVolCondMEG(unittest.TestCase):
     """
-    test class eegmegcalc.MEG
+    test class eegmegcalc.InfiniteHomogeneousVolCondMEG
     """
 
-    def test_MEG_00(self):
+    def test_InfiniteHomogeneousVolCondMEG_00(self):
         '''test eegmegcalc.MEG.calculate_H()'''
         current_dipole_moment = np.zeros((3, 11))
         current_dipole_moment[0, :] += 1.
@@ -41,11 +41,11 @@ class testMEG(unittest.TestCase):
         gt[4, 2, :] = -1. / 4 / np.pi
         gt[5, 1, :] = 1. / 4 / np.pi
 
-        meg = LFPy.MEG(sensor_locations)
+        meg = LFPy.InfiniteHomogeneousVolCondMEG(sensor_locations)
         np.testing.assert_equal(gt, meg.calculate_H(current_dipole_moment,
                                                     dipole_location))
 
-    def test_MEG_01(self):
+    def test_InfiniteHomogeneousVolCondMEG_01(self):
         '''test eegmegcalc.MEG.calculate_H()'''
         current_dipole_moment = np.zeros((3, 11))
         current_dipole_moment[1, :] += 1.
@@ -59,11 +59,11 @@ class testMEG(unittest.TestCase):
         gt[3, 2, :] = 1. / 4 / np.pi
         gt[5, 0, :] = -1. / 4 / np.pi
 
-        meg = LFPy.MEG(sensor_locations)
+        meg = LFPy.InfiniteHomogeneousVolCondMEG(sensor_locations)
         np.testing.assert_equal(gt, meg.calculate_H(current_dipole_moment,
                                                     dipole_location))
 
-    def test_MEG_02(self):
+    def test_InfiniteHomogeneousVolCondMEG_02(self):
         '''test eegmegcalc.MEG.calculate_H()'''
         current_dipole_moment = np.zeros((3, 11))
         current_dipole_moment[2, :] += 1.
@@ -78,11 +78,11 @@ class testMEG(unittest.TestCase):
         gt[3, 1, :] = -1. / 4 / np.pi
         gt[4, 0, :] = 1. / 4 / np.pi
 
-        meg = LFPy.MEG(sensor_locations)
+        meg = LFPy.InfiniteHomogeneousVolCondMEG(sensor_locations)
         np.testing.assert_equal(gt, meg.calculate_H(current_dipole_moment,
                                                     dipole_location))
 
-    def test_MEG_03(self):
+    def test_InfiniteHomogeneousVolCondMEG_03(self):
         '''test eegmegcalc.MEG.calculate_H()'''
         current_dipole_moment = np.zeros((3, 1))
         current_dipole_moment[0, :] += 1.
@@ -96,11 +96,11 @@ class testMEG(unittest.TestCase):
         gt[4, 2, :] = -1. / 4 / np.pi
         gt[5, 1, :] = 1. / 4 / np.pi
 
-        meg = LFPy.MEG(sensor_locations)
+        meg = LFPy.InfiniteHomogeneousVolCondMEG(sensor_locations)
         np.testing.assert_equal(gt, meg.calculate_H(current_dipole_moment,
                                                     dipole_location))
 
-    def test_MEG_04(self):
+    def test_InfiniteHomogeneousVolCondMEG_04(self):
         '''test eegmegcalc.MEG.calculate_H()'''
         current_dipole_moment = np.zeros((3, 1))
         current_dipole_moment[1, :] += 1.
@@ -114,11 +114,11 @@ class testMEG(unittest.TestCase):
         gt[3, 2, :] = 1. / 4 / np.pi
         gt[5, 0, :] = -1. / 4 / np.pi
 
-        meg = LFPy.MEG(sensor_locations)
+        meg = LFPy.InfiniteHomogeneousVolCondMEG(sensor_locations)
         np.testing.assert_equal(gt, meg.calculate_H(current_dipole_moment,
                                                     dipole_location))
 
-    def test_MEG_05(self):
+    def test_InfiniteHomogeneousVolCondMEG_05(self):
         '''test eegmegcalc.MEG.calculate_H()'''
         current_dipole_moment = np.zeros((3, 1))
         current_dipole_moment[2, :] += 1.
@@ -132,11 +132,11 @@ class testMEG(unittest.TestCase):
         gt[3, 1, :] = -1. / 4 / np.pi
         gt[4, 0, :] = 1. / 4 / np.pi
 
-        meg = LFPy.MEG(sensor_locations)
+        meg = LFPy.InfiniteHomogeneousVolCondMEG(sensor_locations)
         np.testing.assert_equal(gt, meg.calculate_H(current_dipole_moment,
                                                     dipole_location))
 
-    def test_MEG_06(self):
+    def test_InfiniteHomogeneousVolCondMEG_06(self):
         '''test eegmegcalc.MEG.get_transformation_matrix()'''
         current_dipole_moment = np.c_[np.eye(3), -np.eye(3)]
 
@@ -162,7 +162,7 @@ class testMEG(unittest.TestCase):
                         [1., 0., 0., -1., 0., 0.],
                         [0., 0., 0., 0., 0., 0.]]]) / 4 / np.pi
 
-        meg = LFPy.MEG(sensor_locations)
+        meg = LFPy.InfiniteHomogeneousVolCondMEG(sensor_locations)
         M = meg.get_transformation_matrix(dipole_location)
 
         np.testing.assert_equal(gt, M @ current_dipole_moment)

--- a/doc/classes.rst
+++ b/doc/classes.rst
@@ -148,9 +148,17 @@ class :class:`NYHeadModel`
     :show-inheritance:
     :undoc-members:
 
-class :class:`MEG`
-------------------
-.. autoclass:: MEG
+class :class:`InfiniteHomogeneousVolCondMEG`
+--------------------------------------------
+.. autoclass:: InfiniteHomogeneousVolCondMEG
+    :members:
+    :inherited-members:
+    :show-inheritance:
+    :undoc-members:
+
+class :class:`SphericallySymmetricVolCondMEG`
+---------------------------------------------
+.. autoclass:: SphericallySymmetricVolCondMEG
     :members:
     :inherited-members:
     :show-inheritance:

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
         'Cython>=0.20',
         'h5py>=2.5',
         'mpi4py>=1.2',
-        'LFPykit>=0.3'
+        'LFPykit>=0.4.dev0'
     ],
     extras_require={'tests': ['pytest'],
                     'docs': ['sphinx', 'numpydoc', 'sphinx_rtd_theme']


### PR DESCRIPTION
class `MEG` is deprecated, now wrapping classes `InfiniteHomogeneousVolCondMEG` and `SphericallySymmetricVolCondMEG` from `LFPykit.eegmegcalc`. Closes #355 