### PR TITLE
Fix crash with Neuron 8.1; improved Cell.get_idx_parent_children method

### DIFF
--- a/LFPy/cell.py
+++ b/LFPy/cell.py
@@ -1905,11 +1905,11 @@ class Cell(object):
         Exception
             In case keyword argument ``parent`` is invalid
         """
-        err_mssg = f'keyword argument parent={parent} must be a string'
+        err_mssg = f'keyword argument {parent} must be a string'
         if type(parent) is not str:
             raise ValueError(err_mssg)
         if parent not in self.allsecnames:
-            err_mssg = f'keyword argument parent={parent} not in Cell.allsecnames'
+            err_mssg = f'keyword argument {parent} not in Cell.allsecnames'
             raise ValueError(err_mssg)
 
         seclist = [parent]

--- a/LFPy/cell.py
+++ b/LFPy/cell.py
@@ -1888,18 +1888,30 @@ class Cell(object):
     def get_idx_parent_children(self, parent="soma[0]"):
         """
         Get all idx of segments of parent and children sections, i.e. segment
-        idx of sections connected to parent-argument, and also of the parent
+        idx of sections connected to parent-segment, and also of the parent
         segments
 
         Parameters
         ----------
         parent: str
-            name-pattern matching a sectionname. Defaults to "soma[0]"
+            name-pattern matching a valid section name. Defaults to "soma[0]"
 
         Returns
         -------
         ndarray, dtype=int
+
+        Raises
+        ------
+        Exception
+            In case keyword argument ``parent`` is invalid
         """
+        err_mssg = f'keyword argument parent={parent} must be a string'
+        if type(parent) is not str:
+            raise ValueError(err_mssg)
+        if parent not in self.allsecnames:
+            err_mssg = f'keyword argument parent={parent} not in Cell.allsecnames'
+            raise ValueError(err_mssg)
+
         seclist = [parent]
         for sec in self.allseclist:
             if sec.name() == parent:

--- a/LFPy/network.py
+++ b/LFPy/network.py
@@ -625,7 +625,8 @@ class Network(object):
 
             # record spike events
             population._hoc_spike_vectors.append(neuron.h.Vector())
-            cell._hoc_sd_netconlist[-1].record(population._hoc_spike_vectors[-1])
+            cell._hoc_sd_netconlist[-1].record(
+                population._hoc_spike_vectors[-1])
 
         # add population object to dictionary of populations
         self.populations[name] = population

--- a/LFPy/network.py
+++ b/LFPy/network.py
@@ -361,7 +361,7 @@ class NetworkPopulation(object):
         COMM.Barrier()
 
         # container of Vector objects used to record times of action potentials
-        self.spike_vectors = []
+        self._hoc_spike_vectors = []
 
         # set up population of cells on this RANK
         self.gids = [
@@ -624,8 +624,8 @@ class Network(object):
             self.pc.cell(gid, cell._hoc_sd_netconlist[-1])
 
             # record spike events
-            population.spike_vectors.append(neuron.h.Vector())
-            cell._hoc_sd_netconlist[-1].record(population.spike_vectors[-1])
+            population._hoc_spike_vectors.append(neuron.h.Vector())
+            cell._hoc_sd_netconlist[-1].record(population._hoc_spike_vectors[-1])
 
         # add population object to dictionary of populations
         self.populations[name] = population
@@ -1211,9 +1211,10 @@ class Network(object):
         # Collect spike trains across all RANKs to RANK 0
         for name in self.population_names:
             population = self.populations[name]
-            for i in range(len(population.spike_vectors)):
-                population.spike_vectors[i] = \
-                    np.array(population.spike_vectors[i])
+            population.spike_vectors = []
+            for i in range(len(population._hoc_spike_vectors)):
+                population.spike_vectors += \
+                    [population._hoc_spike_vectors[i].as_numpy()]
         if RANK == 0:
             times = []
             gids = []

--- a/LFPy/test/test_cell.py
+++ b/LFPy/test/test_cell.py
@@ -597,6 +597,17 @@ class testCell(unittest.TestCase):
                 section=[
                     'soma[0]', 'dend[0]']))
 
+    def test_cell_get_idx_parent_children_01(self):
+        cell = LFPy.Cell(morphology=os.path.join(LFPy.__path__[0], 'test',
+                                                 'ball_and_sticks.hoc'))
+        for bad_value in [123, 'no_section']:
+            try:
+                cell.get_idx_parent_children(parent=bad_value)
+            except ValueError:
+                pass
+
+
+
     def test_cell_get_idx_name_00(self):
         cell = LFPy.Cell(morphology=os.path.join(LFPy.__path__[0], 'test',
                                                  'ball_and_sticks.hoc'))

--- a/LFPy/test/test_recextelectrode.py
+++ b/LFPy/test/test_recextelectrode.py
@@ -300,25 +300,25 @@ class testRecExtElectrode(unittest.TestCase):
         stick.z[true_bad_comp, 0] = 1000
         bad_comp, reason = MEA._return_comp_outside_slice()
         np.testing.assert_equal(reason, "zstart above")
-        np.testing.assert_equal(true_bad_comp, bad_comp)
+        np.testing.assert_equal(true_bad_comp, stick.get_idx()[bad_comp])
         stick.z[true_bad_comp, 0] = 100
 
         stick.z[true_bad_comp, 0] = -1000
         bad_comp, reason = MEA._return_comp_outside_slice()
         np.testing.assert_equal(reason, "zstart below")
-        np.testing.assert_equal(true_bad_comp, bad_comp)
+        np.testing.assert_equal(true_bad_comp, stick.get_idx()[bad_comp])
         stick.z[true_bad_comp, 0] = 100
 
         stick.z[true_bad_comp, 1] = 1000
         bad_comp, reason = MEA._return_comp_outside_slice()
         np.testing.assert_equal(reason, "zend above")
-        np.testing.assert_equal(true_bad_comp, bad_comp)
+        np.testing.assert_equal(true_bad_comp, stick.get_idx()[bad_comp])
         stick.z[true_bad_comp, 1] = 100
 
         stick.z[true_bad_comp, 1] = -1000
         bad_comp, reason = MEA._return_comp_outside_slice()
         np.testing.assert_equal(reason, "zend below")
-        np.testing.assert_equal(true_bad_comp, bad_comp)
+        np.testing.assert_equal(true_bad_comp, stick.get_idx()[bad_comp])
         stick.z[true_bad_comp, 1] = 100
 
     def test_position_shifted_slice(self):


### PR DESCRIPTION
Closes #414. Closes #412 