### PR TITLE
Creating a cell using an instance of neuron.h.SectionList as morpholo…

### DIFF
--- a/LFPy/cell.py
+++ b/LFPy/cell.py
@@ -197,9 +197,9 @@ class Cell(object):
             else:
                 raise Exception('non-existent file %s' % self.morphology)
         else:
-            assert isinstance(self.morphology, type(neuron.h.SectionList)), \
-                ("Could not recognize Cell keyword argument morphology as " +
-                 "neuron.h.SectionList instance")
+            if not hasattr(self.morphology, "wholetree"):
+                raise TypeError ("Could not recognize Cell keyword argument morphology as " +
+                                "neuron.h.SectionList instance")
 
             # instantiate 3D geometry of all sections
             neuron.h.define_shape()


### PR DESCRIPTION
Replaced an assert isinstance(..., type(neuron.h.SectionList)) with an explicit attribute check using hasattr(self.morphology, "wholetree") to allow for proper detection of neuron.h.SectionList instances.

This avoids false assertion errors since NEURON’s hoc objects do not always behave like normal Python classes, and provides a clearer TypeError if the morphology type is incorrect.