### PR TITLE
fix building cython extension with pip install

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,16 +1,19 @@
 """Build script for Cython extensions, used by poetry's build system."""
 
 import os
+import shutil
+from pathlib import Path
 
 
-def build(setup_kwargs):
+def main():
     """Build Cython extensions when invoked by poetry."""
     try:
         import numpy as np
         from Cython.Build import cythonize
         from Cython.Distutils import build_ext
-        from setuptools import Extension
-
+        from setuptools import Distribution, Extension
+        
+        print("Building Cython extensions")
         ext_modules = [
             Extension(
                 'LFPy.run_simulation',
@@ -23,10 +26,24 @@ def build(setup_kwargs):
                 include_dirs=[np.get_include()],
             ),
         ]
-        setup_kwargs.update({
-            'ext_modules': cythonize(ext_modules),
-            'cmdclass': {'build_ext': build_ext},
+        distribution = Distribution({
+            "name": "LFPy",
+            "ext_modules": cythonize(ext_modules),
         })
+
+        cmd = build_ext(distribution)
+        cmd.ensure_finalized()
+        cmd.run()
+
+        for output in cmd.get_outputs():
+            output = Path(output)
+            relative_extension = output.relative_to(cmd.build_lib)
+            print(f"Copying {output} -> {relative_extension}")
+            shutil.copyfile(output, relative_extension)
     except ImportError:
         print("'Cython' or 'numpy' not found – Cython extensions will not be "
               "compiled and simulations in LFPy may run slower.")
+
+
+if __name__ == "__main__":
+    main()

--- a/build.py
+++ b/build.py
@@ -12,7 +12,7 @@ def main():
         from Cython.Build import cythonize
         from Cython.Distutils import build_ext
         from setuptools import Distribution, Extension
-        
+
         print("Building Cython extensions")
         ext_modules = [
             Extension(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ include = [
     "LFPy/test/*.py",
     "LFPy/test/sinsyn.mod",
     "LFPy/test/expsyni.mod",
+    { path = "LFPy/**/*.so", format = "wheel" }
 ]
 classifiers = [
     "License :: OSI Approved :: GNU General Public License (GPL)",
@@ -40,7 +41,7 @@ classifiers = [
 
 [tool.poetry.build]
 script = "build.py"
-generate-setup-file = true
+generate-setup-file = false
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
poetry backend apparently invokes `build.py` as a plain script, not `build(setup_kwargs)`

follows [cython example in poetry docs](https://python-poetry.org/docs/building-extension-modules/#cython-pyproject)

poetry still doesn't work as a standard build backend for e.g. `python3 -m build .`, I'm not sure why, but it does for `pip install`

might help with #480 (but won't if uses standard pep517 builds instead of pip)